### PR TITLE
Fix: mapping - handle empty arrays

### DIFF
--- a/Nop.Plugin.Api/Helpers/MappingHelper.cs
+++ b/Nop.Plugin.Api/Helpers/MappingHelper.cs
@@ -95,9 +95,16 @@ namespace Nop.Plugin.Api.Helpers
                 // This case handles collections.
                 if (propertyValue is ICollection<object> propertyValueAsCollection)
                 {
-                    var collectionElementsType = propertyToUpdate.PropertyType.GetGenericArguments()[0];
+                    var collectionElementsType = propertyToUpdate.PropertyType.GetGenericArguments().FirstOrDefault();
+                    
+                    // Treat empty arrays as nulls as we can't be sure of the type
+                    if (collectionElementsType == null)
+                    {
+                        propertyToUpdate.SetValue(objectToBeUpdated, null);
+                        return;
+                    }
+                    
                     var collection = propertyToUpdate.GetValue(objectToBeUpdated);
-
                     if (collection == null)
                     {
                         collection = CreateEmptyList(collectionElementsType);


### PR DESCRIPTION
Treat empty arrays as nulls as we can't be sure of the type.
Resolving issue: https://github.com/stepanbenes/api-for-nopcommerce/issues/66