### PR TITLE
Fix Swagger when running on a virtual root (not '/')

### DIFF
--- a/Nop.Plugin.Api/Configuration/ApiConfiguration.cs
+++ b/Nop.Plugin.Api/Configuration/ApiConfiguration.cs
@@ -7,5 +7,7 @@ namespace Nop.Plugin.Api.Configuration
         public int AllowedClockSkewInMinutes { get; set; } = 5;
 
         public string SecurityKey { get; set; } = "NowIsTheTimeForAllGoodMenToComeToTheAideOfTheirCountry";
+        
+
     }
 }

--- a/Nop.Plugin.Api/Controllers/CategoriesController.cs
+++ b/Nop.Plugin.Api/Controllers/CategoriesController.cs
@@ -69,7 +69,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories", Name = "GetCategories")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -110,7 +110,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories/count", Name = "GetCategoriesCount")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(CategoriesCountRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -139,7 +139,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories/{id}", Name = "GetCategoryById")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.NotFound)]
@@ -172,7 +172,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/categories", Name = "CreateCategory")]
-        [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -240,7 +240,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/categories/{id}", Name = "UpdateCategory")]
-        [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -303,7 +303,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/categories/{id}", Name = "DeleteCategory")]
-        [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
@@ -49,7 +49,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/customer_roles", Name = "GetAllCustomerRoles")]
-        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers))]
         [ProducesResponseType(typeof(CustomerRolesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]

--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -32,7 +32,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers))]
     public class CustomersController : BaseApiController
     {
         private readonly ICountryService _countryService;
@@ -152,7 +152,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/customers/me", Name = "GetCurrentCustomer")]
-        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
         [ProducesResponseType(typeof(CustomersRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -479,7 +479,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("api/customers/{customerId}/billingaddress", Name = "SetBillingAddress")]
-        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, ignore: true)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers), ignore: true)]
         [GetRequestsErrorInterceptorActionFilter]
         [ProducesResponseType(typeof(AddressDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -505,7 +505,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("api/customers/{customerId}/shippingaddress", Name = "SetShippingAddress")]
-        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, ignore: true)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers), ignore: true)]
         [GetRequestsErrorInterceptorActionFilter]
         [ProducesResponseType(typeof(AddressDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -574,7 +574,7 @@ namespace Nop.Plugin.Api.Controllers
                 return true;
             }
             // if I want to handle other customer's info, check admin permission
-            return await _permissionService.AuthorizeAsync(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, currentCustomer);
+            return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageCustomers), currentCustomer);
         }
 
 

--- a/Nop.Plugin.Api/Controllers/ManufacturersController.cs
+++ b/Nop.Plugin.Api/Controllers/ManufacturersController.cs
@@ -29,7 +29,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageManufacturers))]
     public class ManufacturersController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
+++ b/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
@@ -22,7 +22,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Promotions.SUBSCRIBERS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageNewsletterSubscribers))]
     public class NewsLetterSubscriptionController : BaseApiController
     {
         private readonly INewsLetterSubscriptionApiService _newsLetterSubscriptionApiService;

--- a/Nop.Plugin.Api/Controllers/OrderItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/OrderItemsController.cs
@@ -28,7 +28,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageOrders))]
     public class OrderItemsController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -543,10 +543,10 @@ namespace Nop.Plugin.Api.Controllers
             if (customerId.HasValue && currentCustomer.Id == customerId)
             {
                 // if I want to handle my own orders, check only public store permission
-                return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_SHOPPING_CART, currentCustomer);
+                return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableShoppingCart), currentCustomer);
             }
             // if I want to handle other customer's orders, check admin permission
-            return await _permissionService.AuthorizeAsync(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE, currentCustomer);
+            return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageOrders), currentCustomer);
         }
 
         private async Task<bool> SetShippingOptionAsync(

--- a/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
@@ -24,8 +24,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageAttributes))]
     public class ProductAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
@@ -24,8 +24,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
-    [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
     public class ProductCategoryMappingsController : BaseApiController
     {
         private readonly ICategoryApiService _categoryApiService;

--- a/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
@@ -24,8 +24,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
-    [AuthorizePermission(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageManufacturers))]
     public class ProductManufacturerMappingsController : BaseApiController
     {
         private readonly IManufacturerApiService _manufacturerApiService;

--- a/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
@@ -24,8 +24,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
-    [AuthorizePermission(StandardPermission.Catalog.SPECIFICATION_ATTRIBUTES_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageAttributes))]
     public class ProductSpecificationAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
@@ -24,7 +24,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
     public class ProductWarehouseInventoryController : BaseApiController
     {
         private readonly IProductApiService _productApiService;

--- a/Nop.Plugin.Api/Controllers/ProductsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductsController.cs
@@ -79,7 +79,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products", Name = "GetProducts")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -120,7 +120,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products/count", Name = "GetProductsCount")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(ProductsCountRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -149,7 +149,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products/{id}", Name = "GetProductById")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -181,7 +181,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpGet]
         [Route("/api/products/categories", Name = "GetProductCategories")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(ProductCategoriesRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -215,7 +215,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/products", Name = "CreateProduct")]
-        [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
@@ -274,7 +274,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/products/{id}", Name = "UpdateProduct")]
-        [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -346,7 +346,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/products/{id}", Name = "DeleteProduct")]
-        [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
@@ -479,16 +479,16 @@ namespace Nop.Plugin.Api.Controllers
                 switch (shoppingCartType)
                 {
                     case ShoppingCartType.ShoppingCart:
-                        return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_SHOPPING_CART, currentCustomer);
+                        return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableShoppingCart), currentCustomer);
                     case ShoppingCartType.Wishlist:
-                        return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_WISHLIST, currentCustomer);
+                        return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableWishlist), currentCustomer);
                     default:
-                        return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_SHOPPING_CART, currentCustomer)
-                          && await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_WISHLIST, currentCustomer);
+                        return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableShoppingCart), currentCustomer)
+                          && await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableWishlist), currentCustomer);
                 }
             }
             // if I want to handle other customer's shopping carts, check admin permission
-            return await _permissionService.AuthorizeAsync(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE, currentCustomer);
+            return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageOrders), currentCustomer);
         }
 
         private async Task<ShoppingCartItemsRootObject> LoadCurrentShoppingCartItems(ShoppingCartType shoppingCartType, Core.Domain.Customers.Customer customer)

--- a/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
@@ -24,7 +24,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.SPECIFICATION_ATTRIBUTES_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageAttributes))]
     public class SpecificationAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/StoreController.cs
+++ b/Nop.Plugin.Api/Controllers/StoreController.cs
@@ -18,7 +18,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Configuration.MANAGE_STORES)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageStores))]
     public class StoreController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;
@@ -56,7 +56,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <param name="fields">Fields you want your json to contain</param>
         [HttpGet]
         [Route("/api/stores/current", Name = "GetCurrentStore")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_STORES, ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageStores), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
         [ProducesResponseType(typeof(StoresRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/TaxesController.cs
+++ b/Nop.Plugin.Api/Controllers/TaxesController.cs
@@ -21,7 +21,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Configuration.MANAGE_TAX_SETTINGS)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageTaxSettings))]
     public class TaxesController : BaseApiController
     {
         private readonly ITaxCategoryService _taxCategoryService;

--- a/Nop.Plugin.Api/Controllers/TokenController.cs
+++ b/Nop.Plugin.Api/Controllers/TokenController.cs
@@ -178,7 +178,9 @@ namespace Nop.Plugin.Api.Controllers
                     claims.Add(new Claim(ClaimTypes.Name, customer.Email));
                 }
             }
-            var apiConfiguration = Singleton<AppSettings>.Instance.Get<ApiConfiguration>();
+            //fix due to nopCommerce 4.7 invert the order of the plugin initialization and the AppSettings singleton initialization
+            //var apiConfiguration = Singleton<AppSettings>.Instance.Get<ApiConfiguration>();
+            var apiConfiguration = new ApiConfiguration();
             var signingCredentials = new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(apiConfiguration.SecurityKey)), SecurityAlgorithms.HmacSha256);
             var token = new JwtSecurityToken(new JwtHeader(signingCredentials), new JwtPayload(claims));
             var accessToken = new JwtSecurityTokenHandler().WriteToken(token);

--- a/Nop.Plugin.Api/Controllers/TopicsController.cs
+++ b/Nop.Plugin.Api/Controllers/TopicsController.cs
@@ -25,7 +25,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.ContentManagement.TOPICS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageTopics))]
     public class TopicsController : BaseApiController
     {
         private readonly ITopicService _topicService;

--- a/Nop.Plugin.Api/Controllers/WarehousesController.cs
+++ b/Nop.Plugin.Api/Controllers/WarehousesController.cs
@@ -67,7 +67,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/warehouses", Name = "GetWarehouses")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -99,7 +99,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/warehouses/{id}", Name = "GetWarehouseById")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.NotFound)]
@@ -132,7 +132,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/warehouses", Name = "CreateWarehouse")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -183,7 +183,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/warehouses/{id}", Name = "UpdateWarehouse")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -238,7 +238,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/warehouses/{id}", Name = "DeleteWarehouse")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Infrastructure/ApiStartup.cs
+++ b/Nop.Plugin.Api/Infrastructure/ApiStartup.cs
@@ -189,7 +189,7 @@ namespace Nop.Plugin.Api.Infrastructure
                       a.UseSwaggerUI(c =>
                 {
                     c.RoutePrefix = "api/swagger";
-                    c.SwaggerEndpoint("/api/swagger/v1/swagger.json", "Nop.Plugin.Api v4.80");
+                    c.SwaggerEndpoint("/api/swagger/v1/swagger.json", "Nop.Plugin.Api v4.70");
                     c.DocExpansion(Swashbuckle.AspNetCore.SwaggerUI.DocExpansion.None);
                 });
                   }

--- a/Nop.Plugin.Api/Infrastructure/ApiStartup.cs
+++ b/Nop.Plugin.Api/Infrastructure/ApiStartup.cs
@@ -61,7 +61,9 @@ namespace Nop.Plugin.Api.Infrastructure
 
             if (apiConfigSection != null)
             {
-                var apiConfig = Singleton<AppSettings>.Instance.Get<ApiConfiguration>();
+                //fix due to nopCommerce 4.7 invert the order of the plugin initialization and the AppSettings singleton initialization
+               // var apiConfig = Singleton<AppSettings>.Instance.Get<ApiConfiguration>();
+               var apiConfig = new ApiConfiguration();
 
 
                 if (!string.IsNullOrEmpty(apiConfig.SecurityKey))

--- a/Nop.Plugin.Api/Services/AddressApiService.cs
+++ b/Nop.Plugin.Api/Services/AddressApiService.cs
@@ -13,7 +13,7 @@ namespace Nop.Plugin.Api.Services
 {
     public class AddressApiService : IAddressApiService
     {
-        private readonly IShortTermCacheManager _cacheManager;
+        private readonly IShortTermCacheManager _shortTermCacheManager;
         private readonly ICountryService _countryService;
         private readonly IStateProvinceService _stateProvinceService;
         private readonly IRepository<Address> _addressRepository;
@@ -22,13 +22,13 @@ namespace Nop.Plugin.Api.Services
         public AddressApiService(
             IRepository<Address> addressRepository,
             IRepository<CustomerAddressMapping> customerAddressMappingRepository,
-            IShortTermCacheManager staticCacheManager,
+            IShortTermCacheManager shortTermShortTermCacheManager,
             ICountryService countryService,
             IStateProvinceService stateProvinceService)
         {
             _addressRepository = addressRepository;
             _customerAddressMappingRepository = customerAddressMappingRepository;
-            _cacheManager = staticCacheManager;
+            _shortTermCacheManager = shortTermShortTermCacheManager;
             _countryService = countryService;
             _stateProvinceService = stateProvinceService;
         }
@@ -47,11 +47,9 @@ namespace Nop.Plugin.Api.Services
                         join cam in _customerAddressMappingRepository.Table on address.Id equals cam.AddressId
                         where cam.CustomerId == customerId
                         select address;
+            
 
-            var key = _cacheManager.PrepareKey(NopCustomerServicesDefaults.CustomerAddressesCacheKey, customerId);
-
-
-            var addresses = await _cacheManager.GetAsync(async () => await query.ToListAsync(), key);
+            var addresses = await _shortTermCacheManager.GetAsync(async () => await query.ToListAsync(),NopCustomerServicesDefaults.CustomerAddressesCacheKey, customerId);
             return addresses.Select(a => a.ToDto()).ToList();
         }
 
@@ -70,10 +68,9 @@ namespace Nop.Plugin.Api.Services
                         join cam in _customerAddressMappingRepository.Table on address.Id equals cam.AddressId
                         where cam.CustomerId == customerId && address.Id == addressId
                         select address;
+ 
 
-            var key = _cacheManager.PrepareKey(NopCustomerServicesDefaults.CustomerAddressesCacheKey, customerId, addressId);
-
-            var addressEntity = await _cacheManager.GetAsync(async () => await query.FirstOrDefaultAsync(), key);
+            var addressEntity = await _shortTermCacheManager.GetAsync( async () => await query.FirstOrDefaultAsync(),NopCustomerServicesDefaults.CustomerAddressCacheKey, customerId, addressId );
             return addressEntity?.ToDto();
         }
 

--- a/Nop.Plugin.Api/plugin.json
+++ b/Nop.Plugin.Api/plugin.json
@@ -1,11 +1,11 @@
 ﻿{
-  "Group": "Api",
-  "FriendlyName": "Api plugin",
-  "SystemName": "Nop.Plugin.Api",
-  "Version": "4.8.0",
-  "SupportedVersions": [ "4.80" ],
-  "Author": "Nop-Templates team",
-  "DisplayOrder": -1,
-  "FileName": "Nop.Plugin.Api.dll",
-  "Description": "This plugin is Restfull API for nopCommerce"
+    "Group": "Api",
+    "FriendlyName": "Api plugin",
+    "SystemName": "Nop.Plugin.Api",
+    "Version": "4.7.0",
+    "SupportedVersions": [ "4.70" ],
+    "Author": "Nop-Templates team",
+    "DisplayOrder": -1,
+    "FileName": "Nop.Plugin.Api.dll",
+    "Description": "This plugin is Restfull API for nopCommerce"
 }


### PR DESCRIPTION
Swagger always tries to use the API definition from /api/ even if the app is hosted in a virtual root. This PR adds the vroot path to the API definition location so this works correctly.

I built this against a 4.7 branch due to a NopCommerce issue that's preventing me from upgrading to 4.8 now.