### PR TITLE
Fix 403 Forbidden errors: Remove incorrect nameof() from permission constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI Build
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+
+env:
+  # nopCommerce version that matches the plugin's SupportedVersions in plugin.json
+  NOPCOMMERCE_VERSION: release-4.90.3
+  DOTNET_VERSION: '9.0.x'
+  # Build configuration
+  CONFIGURATION: Release
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout API repository
+      uses: actions/checkout@v4
+      with:
+        path: api-for-nopcommerce
+
+    - name: Checkout nopCommerce at ${{ env.NOPCOMMERCE_VERSION }}
+      uses: actions/checkout@v4
+      with:
+        repository: nopSolutions/nopCommerce
+        ref: ${{ env.NOPCOMMERCE_VERSION }}
+        path: nopCommerce
+    
+    - name: Setup .NET ${{ env.DOTNET_VERSION }}
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+    
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    
+    - name: Restore nopCommerce dependencies
+      run: dotnet restore
+      working-directory: nopCommerce/src
+    
+    - name: Build nopCommerce
+      run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
+      working-directory: nopCommerce/src
+    
+    - name: Restore API plugin dependencies
+      run: dotnet restore
+      working-directory: api-for-nopcommerce
+    
+    - name: Build API plugin
+      run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
+      working-directory: api-for-nopcommerce
+    
+    - name: Verify build output
+      run: |
+        echo "✅ Build completed successfully!"
+        echo ""
+        echo "Plugin output directory:"
+        if [ -d "nopCommerce/src/Presentation/Nop.Web/Plugins/Nop.Plugin.Api" ]; then
+          ls -lh nopCommerce/src/Presentation/Nop.Web/Plugins/Nop.Plugin.Api/
+          echo ""
+          echo "Plugin DLL found at expected location"
+        else
+          echo "⚠️ Plugin directory not found at expected location"
+          exit 1
+        fi
+      
+    # Note: Tests are commented out due to .NET Framework 4.6.1 compatibility issues
+    # The test project (Nop.Plugin.Api.Tests) uses net461 which is not supported on Linux runners
+    # To enable tests, the test project needs to be upgraded to .NET 6+ and project references fixed
+    # - name: Run tests
+    #   run: dotnet test --configuration ${{ env.CONFIGURATION }} --no-build --verbosity normal
+    #   working-directory: api-for-nopcommerce

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
         dotnet build nopCommerce/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj --configuration ${{ env.CONFIGURATION }}
     
     - name: Build API plugin
-      run: dotnet build --configuration ${{ env.CONFIGURATION }}
+      run: |
+        echo "Building API plugin projects (excluding outdated ClientApp)..."
+        dotnet build Nop.Plugin.Api/Nop.Plugin.Api.csproj --configuration ${{ env.CONFIGURATION }}
       working-directory: api-for-nopcommerce
     
     - name: Verify build output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,20 +45,14 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
     
-    - name: Restore nopCommerce dependencies
-      run: dotnet restore
-      working-directory: nopCommerce/src
-    
-    - name: Build nopCommerce
-      run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
-      working-directory: nopCommerce/src
-    
-    - name: Restore API plugin dependencies
-      run: dotnet restore
-      working-directory: api-for-nopcommerce
+    - name: Build required nopCommerce dependencies
+      run: |
+        echo "Building only required nopCommerce projects (Nop.Core and Nop.Web.Framework)..."
+        dotnet build nopCommerce/src/Libraries/Nop.Core/Nop.Core.csproj --configuration ${{ env.CONFIGURATION }}
+        dotnet build nopCommerce/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj --configuration ${{ env.CONFIGURATION }}
     
     - name: Build API plugin
-      run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
+      run: dotnet build --configuration ${{ env.CONFIGURATION }}
       working-directory: api-for-nopcommerce
     
     - name: Verify build output

--- a/ClientApp/ClientApp.csproj
+++ b/ClientApp/ClientApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Nop.Plugin.Api/AutoMapper/ApiMapperConfiguration.cs
+++ b/Nop.Plugin.Api/AutoMapper/ApiMapperConfiguration.cs
@@ -31,6 +31,7 @@ using Nop.Plugin.Api.DTO.ShoppingCarts;
 using Nop.Plugin.Api.DTO.SpecificationAttributes;
 using Nop.Plugin.Api.DTO.Stores;
 using Nop.Plugin.Api.DTO.Warehouses;
+using Nop.Plugin.Api.DTOs.ShipmentItems;
 using Nop.Plugin.Api.DTOs.StateProvinces;
 using Nop.Plugin.Api.DTOs.Taxes;
 using Nop.Plugin.Api.DTOs.Topics;
@@ -74,6 +75,8 @@ namespace Nop.Plugin.Api.AutoMapper
 
             CreateMap<OrderItem, OrderItemDto>();
             CreateOrderEntityToOrderDtoMap();
+            CreateMap<Shipment, ShipmentDto>();
+            CreateMap<ShipmentItem, ShipmentItemDto>();
 
             CreateProductMap();
 
@@ -103,9 +106,9 @@ namespace Nop.Plugin.Api.AutoMapper
 
         public int Order => 0;
 
-        private new static void CreateMap<TSource, TDestination>()
+        private new static IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>()
         {
-            AutoMapperApiConfiguration.MapperConfigurationExpression.CreateMap<TSource, TDestination>()
+            return AutoMapperApiConfiguration.MapperConfigurationExpression.CreateMap<TSource, TDestination>()
                                       .IgnoreAllNonExisting();
         }
 
@@ -125,7 +128,7 @@ namespace Nop.Plugin.Api.AutoMapper
                                       .ForMember(x => x.Id, y => y.MapFrom(src => src.Id));
             //.ForMember(x => x.OrderItems, y => y.MapFrom(src => src.OrderItems.Select(x => x.ToDto())));
         }
-
+        
         private void CreateAddressMap()
         {
             AutoMapperApiConfiguration.MapperConfigurationExpression.CreateMap<Address, AddressDto>()

--- a/Nop.Plugin.Api/Configuration/ApiConfiguration.cs
+++ b/Nop.Plugin.Api/Configuration/ApiConfiguration.cs
@@ -7,5 +7,7 @@ namespace Nop.Plugin.Api.Configuration
         public int AllowedClockSkewInMinutes { get; set; } = 5;
 
         public string SecurityKey { get; set; } = "NowIsTheTimeForAllGoodMenToComeToTheAideOfTheirCountry";
+        
+
     }
 }

--- a/Nop.Plugin.Api/Controllers/CategoriesController.cs
+++ b/Nop.Plugin.Api/Controllers/CategoriesController.cs
@@ -69,7 +69,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories", Name = "GetCategories")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -110,7 +110,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories/count", Name = "GetCategoriesCount")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(CategoriesCountRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -139,7 +139,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories/{id}", Name = "GetCategoryById")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.NotFound)]
@@ -172,7 +172,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/categories", Name = "CreateCategory")]
-        [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -240,7 +240,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/categories/{id}", Name = "UpdateCategory")]
-        [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -303,7 +303,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/categories/{id}", Name = "DeleteCategory")]
-        [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/CategoriesController.cs
+++ b/Nop.Plugin.Api/Controllers/CategoriesController.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿﻿using Microsoft.AspNetCore.Mvc;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Discounts;
 using Nop.Core.Domain.Media;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Categories;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.Images;

--- a/Nop.Plugin.Api/Controllers/CategoriesController.cs
+++ b/Nop.Plugin.Api/Controllers/CategoriesController.cs
@@ -70,7 +70,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories", Name = "GetCategories")]
-        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
+        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -111,7 +111,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories/count", Name = "GetCategoriesCount")]
-        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
+        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
         [ProducesResponseType(typeof(CategoriesCountRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -140,7 +140,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories/{id}", Name = "GetCategoryById")]
-        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
+        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.NotFound)]
@@ -173,7 +173,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/categories", Name = "CreateCategory")]
-        [AuthorizePermission(nameof(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE))]
+        [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -241,7 +241,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/categories/{id}", Name = "UpdateCategory")]
-        [AuthorizePermission(nameof(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE))]
+        [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -304,7 +304,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/categories/{id}", Name = "DeleteCategory")]
-        [AuthorizePermission(nameof(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE))]
+        [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/CategoriesController.cs
+++ b/Nop.Plugin.Api/Controllers/CategoriesController.cs
@@ -70,7 +70,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories", Name = "GetCategories")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
+        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -111,7 +111,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories/count", Name = "GetCategoriesCount")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
+        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
         [ProducesResponseType(typeof(CategoriesCountRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -140,7 +140,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/categories/{id}", Name = "GetCategoryById")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
+        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.NotFound)]
@@ -173,7 +173,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/categories", Name = "CreateCategory")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
+        [AuthorizePermission(nameof(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -241,7 +241,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/categories/{id}", Name = "UpdateCategory")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
+        [AuthorizePermission(nameof(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE))]
         [ProducesResponseType(typeof(CategoriesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -304,7 +304,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/categories/{id}", Name = "DeleteCategory")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
+        [AuthorizePermission(nameof(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE))]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
@@ -49,7 +49,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/customer_roles", Name = "GetAllCustomerRoles")]
-        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers))]
         [ProducesResponseType(typeof(CustomerRolesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]

--- a/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
@@ -50,7 +50,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/customer_roles", Name = "GetAllCustomerRoles")]
-        [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE))]
+        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE)]
         [ProducesResponseType(typeof(CustomerRolesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]

--- a/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.CustomerRoles;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.JSON.ActionResults;

--- a/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomerRolesController.cs
@@ -50,7 +50,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/customer_roles", Name = "GetAllCustomerRoles")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers))]
+        [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE))]
         [ProducesResponseType(typeof(CustomerRolesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]

--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -32,7 +32,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers))]
     public class CustomersController : BaseApiController
     {
         private readonly ICountryService _countryService;
@@ -152,7 +152,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/customers/me", Name = "GetCurrentCustomer")]
-        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
         [ProducesResponseType(typeof(CustomersRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -479,7 +479,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("api/customers/{customerId}/billingaddress", Name = "SetBillingAddress")]
-        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, ignore: true)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers), ignore: true)]
         [GetRequestsErrorInterceptorActionFilter]
         [ProducesResponseType(typeof(AddressDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -505,7 +505,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("api/customers/{customerId}/shippingaddress", Name = "SetShippingAddress")]
-        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, ignore: true)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers), ignore: true)]
         [GetRequestsErrorInterceptorActionFilter]
         [ProducesResponseType(typeof(AddressDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -574,7 +574,7 @@ namespace Nop.Plugin.Api.Controllers
                 return true;
             }
             // if I want to handle other customer's info, check admin permission
-            return await _permissionService.AuthorizeAsync(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, currentCustomer);
+            return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageCustomers), currentCustomer);
         }
 
 

--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -33,7 +33,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers))]
+    [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE))]
     public class CustomersController : BaseApiController
     {
         private readonly ICountryService _countryService;
@@ -153,7 +153,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/customers/me", Name = "GetCurrentCustomer")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
+        [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
         [ProducesResponseType(typeof(CustomersRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -480,7 +480,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("api/customers/{customerId}/billingaddress", Name = "SetBillingAddress")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers), ignore: true)]
+        [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE), ignore: true)]
         [GetRequestsErrorInterceptorActionFilter]
         [ProducesResponseType(typeof(AddressDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -506,7 +506,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("api/customers/{customerId}/shippingaddress", Name = "SetShippingAddress")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageCustomers), ignore: true)]
+        [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE), ignore: true)]
         [GetRequestsErrorInterceptorActionFilter]
         [ProducesResponseType(typeof(AddressDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -575,7 +575,7 @@ namespace Nop.Plugin.Api.Controllers
                 return true;
             }
             // if I want to handle other customer's info, check admin permission
-            return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageCustomers), currentCustomer);
+            return await _permissionService.AuthorizeAsync(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE), currentCustomer);
         }
 
 

--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Nop.Core.Domain.Common;
 using Nop.Core.Domain.Customers;
 using Nop.Core.Infrastructure;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO;
 using Nop.Plugin.Api.DTO.Customers;
 using Nop.Plugin.Api.DTO.Errors;
@@ -464,8 +465,8 @@ namespace Nop.Plugin.Api.Controllers
             //remove newsletter subscription (if exists)
             foreach (var store in await StoreService.GetAllStoresAsync())
             {
-                var subscription = await _newsLetterSubscriptionService.GetNewsLetterSubscriptionByEmailAndStoreIdAsync(customer.Email, store.Id);
-                if (subscription != null)
+                var subscriptions = await _newsLetterSubscriptionService.GetNewsLetterSubscriptionsByEmailAsync(customer.Email, store.Id);
+                foreach (var subscription in subscriptions)
                 {
                     await _newsLetterSubscriptionService.DeleteNewsLetterSubscriptionAsync(subscription);
                 }

--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -33,7 +33,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE)]
     public class CustomersController : BaseApiController
     {
         private readonly ICountryService _countryService;
@@ -153,7 +153,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/customers/me", Name = "GetCurrentCustomer")]
-        [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
+        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
         [ProducesResponseType(typeof(CustomersRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -480,7 +480,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("api/customers/{customerId}/billingaddress", Name = "SetBillingAddress")]
-        [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE), ignore: true)]
+        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, ignore: true)]
         [GetRequestsErrorInterceptorActionFilter]
         [ProducesResponseType(typeof(AddressDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -506,7 +506,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("api/customers/{customerId}/shippingaddress", Name = "SetShippingAddress")]
-        [AuthorizePermission(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE), ignore: true)]
+        [AuthorizePermission(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, ignore: true)]
         [GetRequestsErrorInterceptorActionFilter]
         [ProducesResponseType(typeof(AddressDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -575,7 +575,7 @@ namespace Nop.Plugin.Api.Controllers
                 return true;
             }
             // if I want to handle other customer's info, check admin permission
-            return await _permissionService.AuthorizeAsync(nameof(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE), currentCustomer);
+            return await _permissionService.AuthorizeAsync(StandardPermission.Customers.CUSTOMERS_CREATE_EDIT_DELETE, currentCustomer);
         }
 
 

--- a/Nop.Plugin.Api/Controllers/ManufacturersController.cs
+++ b/Nop.Plugin.Api/Controllers/ManufacturersController.cs
@@ -29,7 +29,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageManufacturers))]
     public class ManufacturersController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ManufacturersController.cs
+++ b/Nop.Plugin.Api/Controllers/ManufacturersController.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿﻿using Microsoft.AspNetCore.Mvc;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Discounts;
 using Nop.Core.Domain.Media;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.Images;
 using Nop.Plugin.Api.DTO.Manufacturers;

--- a/Nop.Plugin.Api/Controllers/ManufacturersController.cs
+++ b/Nop.Plugin.Api/Controllers/ManufacturersController.cs
@@ -30,7 +30,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE)]
     public class ManufacturersController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ManufacturersController.cs
+++ b/Nop.Plugin.Api/Controllers/ManufacturersController.cs
@@ -30,7 +30,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageManufacturers))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE))]
     public class ManufacturersController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
+++ b/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
@@ -22,7 +22,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Promotions.SUBSCRIBERS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageNewsletterSubscribers))]
     public class NewsLetterSubscriptionController : BaseApiController
     {
         private readonly INewsLetterSubscriptionApiService _newsLetterSubscriptionApiService;

--- a/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
+++ b/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
@@ -23,7 +23,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Promotions.SUBSCRIBERS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Promotions.SUBSCRIBERS_CREATE_EDIT_DELETE)]
     public class NewsLetterSubscriptionController : BaseApiController
     {
         private readonly INewsLetterSubscriptionApiService _newsLetterSubscriptionApiService;

--- a/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
+++ b/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
@@ -23,7 +23,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageNewsletterSubscribers))]
+    [AuthorizePermission(nameof(StandardPermission.Promotions.SUBSCRIBERS_CREATE_EDIT_DELETE))]
     public class NewsLetterSubscriptionController : BaseApiController
     {
         private readonly INewsLetterSubscriptionApiService _newsLetterSubscriptionApiService;

--- a/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
+++ b/Nop.Plugin.Api/Controllers/NewsLetterSubscriptionController.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Nop.Core;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.NewsLetterSubscriptions;
 using Nop.Plugin.Api.Infrastructure;
@@ -107,7 +108,9 @@ namespace Nop.Plugin.Api.Controllers
                 return Error(HttpStatusCode.BadRequest, "The email parameter could not be empty.");
             }
 
-            var existingSubscription = await _newsLetterSubscriptionService.GetNewsLetterSubscriptionByEmailAndStoreIdAsync(email, _storeContext.GetCurrentStore().Id);
+            var currentStoreId = (await _storeContext.GetCurrentStoreAsync()).Id;
+            var existingSubscriptions = await _newsLetterSubscriptionService.GetNewsLetterSubscriptionsByEmailAsync(email, currentStoreId);
+            var existingSubscription = existingSubscriptions.FirstOrDefault();
 
             if (existingSubscription == null)
             {

--- a/Nop.Plugin.Api/Controllers/OrderItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/OrderItemsController.cs
@@ -28,7 +28,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageOrders))]
     public class OrderItemsController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/OrderItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/OrderItemsController.cs
@@ -29,7 +29,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageOrders))]
+    [AuthorizePermission(nameof(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE))]
     public class OrderItemsController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/OrderItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/OrderItemsController.cs
@@ -29,7 +29,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE)]
     public class OrderItemsController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/OrderItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/OrderItemsController.cs
@@ -4,6 +4,7 @@ using Nop.Core.Domain.Orders;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.OrderItems;
 using Nop.Plugin.Api.Helpers;

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -543,10 +543,10 @@ namespace Nop.Plugin.Api.Controllers
             if (customerId.HasValue && currentCustomer.Id == customerId)
             {
                 // if I want to handle my own orders, check only public store permission
-                return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_SHOPPING_CART, currentCustomer);
+                return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableShoppingCart), currentCustomer);
             }
             // if I want to handle other customer's orders, check admin permission
-            return await _permissionService.AuthorizeAsync(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE, currentCustomer);
+            return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageOrders), currentCustomer);
         }
 
         private async Task<bool> SetShippingOptionAsync(

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -586,10 +586,10 @@ namespace Nop.Plugin.Api.Controllers
             if (customerId.HasValue && currentCustomer.Id == customerId)
             {
                 // if I want to handle my own orders, check only public store permission
-                return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableShoppingCart), currentCustomer);
+                return await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_SHOPPING_CART), currentCustomer);
             }
             // if I want to handle other customer's orders, check admin permission
-            return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageOrders), currentCustomer);
+            return await _permissionService.AuthorizeAsync(nameof(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE), currentCustomer);
         }
         
         private async Task<bool> SetShippingOptionAsync(

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -261,6 +261,48 @@ namespace Nop.Plugin.Api.Controllers
 
             return Ok(ordersRootObject);
         }
+        
+        /// <summary>
+        ///     Retrieve all orders that contain a specified product
+        /// </summary>
+        /// <param name="productId">Id of the product we are checking for</param>
+        /// <response code="200">OK</response>
+        /// <response code="401">Unauthorized</response>
+        [HttpGet]
+        [Route("/api/orders/product/{productId}", Name = nameof(GetOrdersByProductId))]
+        [ProducesResponseType(typeof(OrdersRootObject), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public async Task<IActionResult> GetOrdersByProductId([FromRoute] int productId)
+        {
+            IList<OrderDto> ordersForProduct = await _orderApiService.GetOrdersForProductId(productId)
+                .SelectAwait(async x => await _dtoHelper.PrepareOrderDTOAsync(x)).ToListAsync();
+
+            var ordersRootObject = new OrdersRootObject { Orders = ordersForProduct };
+
+            return Ok(ordersRootObject);
+        }
+        
+        /// <summary>
+        ///     Retrieve all orders that contain a product in mapped to the specified category
+        /// </summary>
+        /// <param name="categoryId">Id of the product we are checking for</param>
+        /// <response code="200">OK</response>
+        /// <response code="401">Unauthorized</response>
+        [HttpGet]
+        [Route("/api/orders/category/{categoryId}", Name = nameof(GetOrdersByCategoryId))]
+        [ProducesResponseType(typeof(OrdersRootObject), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public async Task<IActionResult> GetOrdersByCategoryId([FromRoute] int categoryId)
+        {
+            IList<OrderDto> ordersForCategory = await _orderApiService.GetOrdersForCategoryId(categoryId)
+                .SelectAwait(async x => await _dtoHelper.PrepareOrderDTOAsync(x)).ToListAsync();
+
+            var ordersRootObject = new OrdersRootObject { Orders = ordersForCategory };
+
+            return Ok(ordersRootObject);
+        }
 
         [HttpPost]
         [Route("/api/orders", Name = "CreateOrder")]
@@ -548,7 +590,7 @@ namespace Nop.Plugin.Api.Controllers
             // if I want to handle other customer's orders, check admin permission
             return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageOrders), currentCustomer);
         }
-
+        
         private async Task<bool> SetShippingOptionAsync(
           string shippingRateComputationMethodSystemName, string shippingOptionName, int storeId, Customer customer, List<ShoppingCartItem> shoppingCartItems)
         {

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -586,10 +586,10 @@ namespace Nop.Plugin.Api.Controllers
             if (customerId.HasValue && currentCustomer.Id == customerId)
             {
                 // if I want to handle my own orders, check only public store permission
-                return await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_SHOPPING_CART), currentCustomer);
+                return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_SHOPPING_CART, currentCustomer);
             }
             // if I want to handle other customer's orders, check admin permission
-            return await _permissionService.AuthorizeAsync(nameof(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE), currentCustomer);
+            return await _permissionService.AuthorizeAsync(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE, currentCustomer);
         }
         
         private async Task<bool> SetShippingOptionAsync(

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -269,7 +269,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="200">OK</response>
         /// <response code="401">Unauthorized</response>
         [HttpGet]
-        [Route("/api/orders/product/{productId}", Name = nameof(GetOrdersByProductId))]
+        [Route("/api/products/{productId}/orders", Name = nameof(GetOrdersByProductId))]
         [ProducesResponseType(typeof(OrdersRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -290,7 +290,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="200">OK</response>
         /// <response code="401">Unauthorized</response>
         [HttpGet]
-        [Route("/api/orders/category/{categoryId}", Name = nameof(GetOrdersByCategoryId))]
+        [Route("/api/categories/{categoryId}/orders", Name = nameof(GetOrdersByCategoryId))]
         [ProducesResponseType(typeof(OrdersRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [GetRequestsErrorInterceptorActionFilter]

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -30,6 +30,7 @@ using Nop.Services.Security;
 using Nop.Services.Shipping;
 using Nop.Services.Stores;
 using System.Net;
+using Nop.Plugin.Api.Domain;
 
 namespace Nop.Plugin.Api.Controllers
 {

--- a/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
@@ -24,8 +24,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageAttributes))]
     public class ProductAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
@@ -25,8 +25,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageAttributes))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE))]
     public class ProductAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
@@ -25,8 +25,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
-    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE)]
     public class ProductAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿﻿using Microsoft.AspNetCore.Mvc;
 using Nop.Core.Domain.Catalog;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.ProductAttributes;
 using Nop.Plugin.Api.Helpers;

--- a/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
@@ -24,8 +24,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
-    [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
     public class ProductCategoryMappingsController : BaseApiController
     {
         private readonly ICategoryApiService _categoryApiService;

--- a/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿﻿using Microsoft.AspNetCore.Mvc;
 using Nop.Core.Domain.Catalog;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.ProductCategoryMappings;
 using Nop.Plugin.Api.Infrastructure;

--- a/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
@@ -25,8 +25,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageCategories))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE))]
     public class ProductCategoryMappingsController : BaseApiController
     {
         private readonly ICategoryApiService _categoryApiService;

--- a/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductCategoryMappingsController.cs
@@ -25,8 +25,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
-    [AuthorizePermission(nameof(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(StandardPermission.Catalog.CATEGORIES_CREATE_EDIT_DELETE)]
     public class ProductCategoryMappingsController : BaseApiController
     {
         private readonly ICategoryApiService _categoryApiService;

--- a/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
@@ -24,8 +24,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
-    [AuthorizePermission(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageManufacturers))]
     public class ProductManufacturerMappingsController : BaseApiController
     {
         private readonly IManufacturerApiService _manufacturerApiService;

--- a/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
@@ -25,8 +25,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageManufacturers))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE))]
     public class ProductManufacturerMappingsController : BaseApiController
     {
         private readonly IManufacturerApiService _manufacturerApiService;

--- a/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿﻿using Microsoft.AspNetCore.Mvc;
 using Nop.Core.Domain.Catalog;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.ProductManufacturerMappings;
 using Nop.Plugin.Api.Infrastructure;

--- a/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductManufacturerMappingsController.cs
@@ -25,8 +25,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
-    [AuthorizePermission(nameof(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(StandardPermission.Catalog.MANUFACTURER_CREATE_EDIT_DELETE)]
     public class ProductManufacturerMappingsController : BaseApiController
     {
         private readonly IManufacturerApiService _manufacturerApiService;

--- a/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
@@ -24,8 +24,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
-    [AuthorizePermission(StandardPermission.Catalog.SPECIFICATION_ATTRIBUTES_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageAttributes))]
     public class ProductSpecificationAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
@@ -25,8 +25,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
-    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE)]
     public class ProductSpecificationAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
@@ -13,6 +13,7 @@ using Nop.Plugin.Api.ModelBinders;
 using Nop.Plugin.Api.Models.ProductSpecificationAttributesParameters;
 using Nop.Plugin.Api.Services;
 using Nop.Services.Catalog;
+using Nop.Plugin.Api.Domain;
 using Nop.Services.Customers;
 using Nop.Services.Discounts;
 using Nop.Services.Localization;

--- a/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
@@ -25,8 +25,8 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageAttributes))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE))]
     public class ProductSpecificationAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
@@ -24,7 +24,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
     public class ProductWarehouseInventoryController : BaseApiController
     {
         private readonly IProductApiService _productApiService;

--- a/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
@@ -25,7 +25,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
     public class ProductWarehouseInventoryController : BaseApiController
     {
         private readonly IProductApiService _productApiService;

--- a/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
@@ -25,7 +25,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
     public class ProductWarehouseInventoryController : BaseApiController
     {
         private readonly IProductApiService _productApiService;

--- a/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductWarehouseInventoryController.cs
@@ -3,6 +3,7 @@ using Nop.Core.Domain.Catalog;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.ProductWarehouseIventories;
 using Nop.Plugin.Api.Infrastructure;

--- a/Nop.Plugin.Api/Controllers/ProductsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductsController.cs
@@ -79,7 +79,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products", Name = "GetProducts")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -120,7 +120,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products/count", Name = "GetProductsCount")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(ProductsCountRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -149,7 +149,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products/{id}", Name = "GetProductById")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -181,7 +181,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpGet]
         [Route("/api/products/categories", Name = "GetProductCategories")]
-        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
         [ProducesResponseType(typeof(ProductCategoriesRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -215,7 +215,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/products", Name = "CreateProduct")]
-        [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
@@ -274,7 +274,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/products/{id}", Name = "UpdateProduct")]
-        [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -346,7 +346,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/products/{id}", Name = "DeleteProduct")]
-        [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/ProductsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductsController.cs
@@ -80,7 +80,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products", Name = "GetProducts")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
+        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -121,7 +121,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products/count", Name = "GetProductsCount")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
+        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
         [ProducesResponseType(typeof(ProductsCountRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -150,7 +150,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products/{id}", Name = "GetProductById")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
+        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -182,7 +182,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpGet]
         [Route("/api/products/categories", Name = "GetProductCategories")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.PublicStoreAllowNavigation))]
+        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
         [ProducesResponseType(typeof(ProductCategoriesRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -216,7 +216,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/products", Name = "CreateProduct")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+        [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
@@ -275,7 +275,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/products/{id}", Name = "UpdateProduct")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+        [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -347,7 +347,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/products/{id}", Name = "DeleteProduct")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageProducts))]
+        [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/ProductsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductsController.cs
@@ -4,6 +4,7 @@ using Nop.Core.Domain.Discounts;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.Images;
 using Nop.Plugin.Api.DTO.Products;

--- a/Nop.Plugin.Api/Controllers/ProductsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductsController.cs
@@ -80,7 +80,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products", Name = "GetProducts")]
-        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
+        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -121,7 +121,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products/count", Name = "GetProductsCount")]
-        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
+        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
         [ProducesResponseType(typeof(ProductsCountRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -150,7 +150,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/products/{id}", Name = "GetProductById")]
-        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
+        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -182,7 +182,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpGet]
         [Route("/api/products/categories", Name = "GetProductCategories")]
-        [AuthorizePermission(nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION))]
+        [AuthorizePermission(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)]
         [ProducesResponseType(typeof(ProductCategoriesRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -216,7 +216,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/products", Name = "CreateProduct")]
-        [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
+        [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
@@ -275,7 +275,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/products/{id}", Name = "UpdateProduct")]
-        [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
+        [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
         [ProducesResponseType(typeof(ProductsRootObjectDto), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -347,7 +347,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/products/{id}", Name = "DeleteProduct")]
-        [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE))]
+        [AuthorizePermission(StandardPermission.Catalog.PRODUCTS_CREATE_EDIT_DELETE)]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/ShipmentsController.cs
+++ b/Nop.Plugin.Api/Controllers/ShipmentsController.cs
@@ -1,0 +1,257 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Nop.Plugin.Api.Attributes;
+using Nop.Plugin.Api.Authorization.Attributes;
+using Nop.Plugin.Api.DTO.Errors;
+using Nop.Plugin.Api.Helpers;
+using Nop.Plugin.Api.Infrastructure;
+using Nop.Plugin.Api.JSON.ActionResults;
+using Nop.Plugin.Api.JSON.Serializers;
+using Nop.Plugin.Api.Services;
+using Nop.Services.Customers;
+using Nop.Services.Discounts;
+using Nop.Services.Localization;
+using Nop.Services.Logging;
+using Nop.Services.Media;
+using Nop.Services.Security;
+using Nop.Services.Stores;
+using Nop.Plugin.Api.Delta;
+using System.Net;
+using Nop.Core.Domain.Shipping;
+using Nop.Plugin.Api.DTO.OrderItems;
+using Nop.Plugin.Api.DTOs.Shipments;
+using Nop.Plugin.Api.MappingExtensions;
+using Nop.Plugin.Api.ModelBinders;
+using Nop.Plugin.Api.Models.ShipmentsParameters;
+
+namespace Nop.Plugin.Api.Controllers
+{
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageOrders))]
+    public class ShipmentsController(
+        IJsonFieldsSerializer jsonFieldsSerializer,
+        IAclService aclService,
+        ICustomerService customerService,
+        IStoreMappingService storeMappingService,
+        IStoreService storeService,
+        IDiscountService discountService,
+        ICustomerActivityService customerActivityService,
+        ILocalizationService localizationService,
+        IOrderApiService orderApiService,
+        IShipmentApiService shipmentApiService,
+        IPictureService pictureService,
+        IDTOHelper dtoHelper)
+        : BaseApiController(jsonFieldsSerializer,
+            aclService,
+            customerService,
+            storeMappingService,
+            storeService,
+            discountService,
+            customerActivityService,
+            localizationService,
+            pictureService)
+    {
+        [HttpGet]
+        [Route("/api/orders/{orderId}/shipments", Name = "GetOrderShipments")]
+        [ProducesResponseType(typeof(ShipmentsRootObject), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public async Task<IActionResult> GetOrderShipments([FromRoute] int orderId,
+            [FromQuery] ShipmentsParametersModel parameters)
+        {
+            if (parameters.Limit is < Constants.Configurations.MinLimit or > Constants.Configurations.MaxLimit)
+            {
+                return Error(HttpStatusCode.BadRequest, "limit", "Invalid limit parameter");
+            }
+
+            if (parameters.Page < Constants.Configurations.DefaultPageValue)
+            {
+                return Error(HttpStatusCode.BadRequest, "page", "Invalid request parameters");
+            }
+
+            var order = orderApiService.GetOrderById(orderId);
+
+            if (order == null)
+            {
+                return Error(HttpStatusCode.NotFound, "order", "not found");
+            }
+
+            var allShipmentsForOrder = await shipmentApiService.GetShipmentsForOrderAsync(order, parameters.Limit,
+                parameters.Page,
+                parameters.SinceId);
+
+            var shipmentsRootObject = new ShipmentsRootObject
+            {
+                Shipments = await allShipmentsForOrder
+                    .SelectAwait(async item => await dtoHelper.PrepareShipmentDTOAsync(item)).ToListAsync()
+            };
+
+            var json = JsonFieldsSerializer.Serialize(shipmentsRootObject, parameters.Fields);
+
+            return new RawJsonActionResult(json);
+        }
+
+        [HttpGet]
+        [Route("/api/orders/{orderId}/shipments/{shipmentId}", Name = "GetShipmentByIdForOrder")]
+        [ProducesResponseType(typeof(ShipmentsRootObject), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public async Task<IActionResult> GetShipmentByIdForOrder([FromRoute] int orderId, [FromRoute] int shipmentId,
+            [FromQuery] string fields = "")
+        {
+            var order = orderApiService.GetOrderById(orderId);
+
+            if (order == null)
+            {
+                return Error(HttpStatusCode.NotFound, "order", "not found");
+            }
+
+            var shipment = await shipmentApiService.GetShipmentByIdAsync(shipmentId);
+
+            if (shipment == null)
+            {
+                return Error(HttpStatusCode.NotFound, "shipment", "not found");
+            }
+
+            var shipmentDtos = new List<ShipmentDto>
+            {
+                await dtoHelper.PrepareShipmentDTOAsync(shipment)
+            };
+
+            var shipmentsRootObject = new ShipmentsRootObject
+            {
+                Shipments = shipmentDtos
+            };
+
+            var json = JsonFieldsSerializer.Serialize(shipmentsRootObject, fields);
+
+            return new RawJsonActionResult(json);
+        }
+        
+        [HttpPost]
+        [Route("/api/orders/{orderId}/shipments", Name = "CreateShipment")]
+        [ProducesResponseType(typeof(ShipmentsRootObject), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ErrorsRootObject), 422)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        public async Task<IActionResult> CreateShipment(
+            [FromRoute]
+            int orderId,
+            [FromBody]
+            [ModelBinder(typeof(JsonModelBinder<ShipmentDto>))]
+            Delta<ShipmentDto> shipmentDelta)
+        {
+            // Here we display the errors if the validation has failed at some point.
+            if (!ModelState.IsValid)
+            {
+                return Error();
+            }
+            
+            var order = orderApiService.GetOrderById(orderId);
+            if (order == null)
+            {
+                return Error(HttpStatusCode.NotFound, "order", "not found");
+            }
+            
+            var newShipment = new Shipment
+            {
+                OrderId = orderId,
+                CreatedOnUtc = DateTime.UtcNow
+            };
+            shipmentDelta.Merge(newShipment);
+            await shipmentApiService.InsertShipmentAsync(newShipment);
+            
+            var shipmentItems = shipmentDelta.Dto.ShipmentItems.Select(dto => new ShipmentItem
+            {
+                OrderItemId = dto.OrderItemId,
+                Quantity = dto.Quantity,
+                WarehouseId = dto.WarehouseId,
+                ShipmentId = newShipment.Id
+            }).ToList();
+            await shipmentApiService.InsertShipmentItemsAsync(shipmentItems);
+            
+            await CustomerActivityService.InsertActivityAsync("AddNewShipment", await LocalizationService.GetResourceAsync("ActivityLog.AddNewShipment"), newShipment);
+            var orderItemsRootObject = new ShipmentsRootObject();
+            var shipmentDto = await dtoHelper.PrepareShipmentDTOAsync(newShipment);
+            orderItemsRootObject.Shipments.Add(shipmentDto);
+            var json = JsonFieldsSerializer.Serialize(orderItemsRootObject, string.Empty);
+            return new RawJsonActionResult(json);
+        }
+        
+        [HttpPut]
+        [Route("/api/orders/{orderId}/shipments/{shipmentId}", Name = "UpdateShipment")]
+        [ProducesResponseType(typeof(ShipmentsRootObject), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ErrorsRootObject), 422)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        public async Task<IActionResult> UpdateShipment([FromRoute] int orderId, [FromRoute] int shipmentId,
+            [FromBody]
+            [ModelBinder(typeof(JsonModelBinder<ShipmentDto>))]
+            Delta<ShipmentDto> shipmentDelta)
+        {
+            // Here we display the errors if the validation has failed at some point.
+            if (!ModelState.IsValid)
+            {
+                return Error();
+            }
+
+
+            var order = orderApiService.GetOrderById(orderId);
+
+            if (order == null)
+            {
+                return Error(HttpStatusCode.NotFound, "order", "not found");
+            }
+            
+            var shipmentToUpdate = await shipmentApiService.GetShipmentByIdAsync(shipmentId);
+            if (shipmentToUpdate == null || shipmentToUpdate.OrderId != orderId)
+            {
+                return Error(HttpStatusCode.NotFound, "shipment", "not found");
+            }
+
+            // This is needed because those fields shouldn't be updatable. That is why we save them and after the merge set them back.
+            var createdOnUtc = shipmentToUpdate.CreatedOnUtc;
+
+            shipmentDelta.Merge(shipmentToUpdate);
+
+            shipmentToUpdate.CreatedOnUtc = createdOnUtc;
+
+            await shipmentApiService.UpdateShipmentAsync(shipmentToUpdate);
+            await CustomerActivityService.InsertActivityAsync("UpdateShipment", await LocalizationService.GetResourceAsync("ActivityLog.UpdateShipment"), shipmentToUpdate);
+
+            var shipmentsRootObject = new ShipmentsRootObject();
+
+            shipmentsRootObject.Shipments.Add(shipmentToUpdate.ToDto());
+
+            var json = JsonFieldsSerializer.Serialize(shipmentsRootObject, string.Empty);
+
+            return new RawJsonActionResult(json);
+        }
+        
+        [HttpDelete]
+        [Route("/api/orders/{orderId}/shipments/{shipmentId}", Name = "DeleteShipmentById")]
+        [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public async Task<IActionResult> DeleteShipmentById([FromRoute] int orderId, [FromRoute] int shipmentId)
+        {
+            var order = orderApiService.GetOrderById(orderId);
+
+            if (order == null)
+            {
+                return Error(HttpStatusCode.NotFound, "order", "not found");
+            }
+
+            var shipment = await shipmentApiService.GetShipmentByIdAsync(shipmentId);
+            await shipmentApiService.DeleteShipmentAsync(shipment);
+
+            return new RawJsonActionResult("{}");
+        }
+    }
+}

--- a/Nop.Plugin.Api/Controllers/ShipmentsController.cs
+++ b/Nop.Plugin.Api/Controllers/ShipmentsController.cs
@@ -25,7 +25,7 @@ using Nop.Plugin.Api.Models.ShipmentsParameters;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE)]
     public class ShipmentsController(
         IJsonFieldsSerializer jsonFieldsSerializer,
         IAclService aclService,

--- a/Nop.Plugin.Api/Controllers/ShipmentsController.cs
+++ b/Nop.Plugin.Api/Controllers/ShipmentsController.cs
@@ -25,7 +25,7 @@ using Nop.Plugin.Api.Models.ShipmentsParameters;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageOrders))]
+    [AuthorizePermission(nameof(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE))]
     public class ShipmentsController(
         IJsonFieldsSerializer jsonFieldsSerializer,
         IAclService aclService,

--- a/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
@@ -479,16 +479,16 @@ namespace Nop.Plugin.Api.Controllers
                 switch (shoppingCartType)
                 {
                     case ShoppingCartType.ShoppingCart:
-                        return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_SHOPPING_CART, currentCustomer);
+                        return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableShoppingCart), currentCustomer);
                     case ShoppingCartType.Wishlist:
-                        return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_WISHLIST, currentCustomer);
+                        return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableWishlist), currentCustomer);
                     default:
-                        return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_SHOPPING_CART, currentCustomer)
-                          && await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_WISHLIST, currentCustomer);
+                        return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableShoppingCart), currentCustomer)
+                          && await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableWishlist), currentCustomer);
                 }
             }
             // if I want to handle other customer's shopping carts, check admin permission
-            return await _permissionService.AuthorizeAsync(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE, currentCustomer);
+            return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageOrders), currentCustomer);
         }
 
         private async Task<ShoppingCartItemsRootObject> LoadCurrentShoppingCartItems(ShoppingCartType shoppingCartType, Core.Domain.Customers.Customer customer)

--- a/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
@@ -4,6 +4,7 @@ using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Orders;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.ShoppingCarts;
 using Nop.Plugin.Api.Factories;

--- a/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
@@ -480,16 +480,16 @@ namespace Nop.Plugin.Api.Controllers
                 switch (shoppingCartType)
                 {
                     case ShoppingCartType.ShoppingCart:
-                        return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableShoppingCart), currentCustomer);
+                        return await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_SHOPPING_CART), currentCustomer);
                     case ShoppingCartType.Wishlist:
-                        return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableWishlist), currentCustomer);
+                        return await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_WISHLIST), currentCustomer);
                     default:
-                        return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableShoppingCart), currentCustomer)
-                          && await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.EnableWishlist), currentCustomer);
+                        return await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_SHOPPING_CART), currentCustomer)
+                          && await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_WISHLIST), currentCustomer);
                 }
             }
             // if I want to handle other customer's shopping carts, check admin permission
-            return await _permissionService.AuthorizeAsync(nameof(StandardPermissionProvider.ManageOrders), currentCustomer);
+            return await _permissionService.AuthorizeAsync(nameof(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE), currentCustomer);
         }
 
         private async Task<ShoppingCartItemsRootObject> LoadCurrentShoppingCartItems(ShoppingCartType shoppingCartType, Core.Domain.Customers.Customer customer)

--- a/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Nop.Core;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Orders;
@@ -480,16 +480,16 @@ namespace Nop.Plugin.Api.Controllers
                 switch (shoppingCartType)
                 {
                     case ShoppingCartType.ShoppingCart:
-                        return await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_SHOPPING_CART), currentCustomer);
+                        return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_SHOPPING_CART, currentCustomer);
                     case ShoppingCartType.Wishlist:
-                        return await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_WISHLIST), currentCustomer);
+                        return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_WISHLIST, currentCustomer);
                     default:
-                        return await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_SHOPPING_CART), currentCustomer)
-                          && await _permissionService.AuthorizeAsync(nameof(StandardPermission.PublicStore.ENABLE_WISHLIST), currentCustomer);
+                        return await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_SHOPPING_CART, currentCustomer)
+                          && await _permissionService.AuthorizeAsync(StandardPermission.PublicStore.ENABLE_WISHLIST, currentCustomer);
                 }
             }
             // if I want to handle other customer's shopping carts, check admin permission
-            return await _permissionService.AuthorizeAsync(nameof(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE), currentCustomer);
+            return await _permissionService.AuthorizeAsync(StandardPermission.Orders.ORDERS_CREATE_EDIT_DELETE, currentCustomer);
         }
 
         private async Task<ShoppingCartItemsRootObject> LoadCurrentShoppingCartItems(ShoppingCartType shoppingCartType, Core.Domain.Customers.Customer customer)

--- a/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
@@ -24,7 +24,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Catalog.SPECIFICATION_ATTRIBUTES_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageAttributes))]
     public class SpecificationAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
@@ -25,7 +25,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageAttributes))]
+    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE))]
     public class SpecificationAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
@@ -25,7 +25,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.Catalog.PRODUCT_ATTRIBUTES_CREATE_EDIT_DELETE)]
     public class SpecificationAttributesController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;

--- a/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Nop.Core.Domain.Catalog;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.SpecificationAttributes;
 using Nop.Plugin.Api.Helpers;
@@ -112,7 +113,8 @@ namespace Nop.Plugin.Api.Controllers
         [GetRequestsErrorInterceptorActionFilter]
         public async Task<IActionResult> GetSpecificationAttributesCount([FromQuery] SpecificationAttributesCountParametersModel parameters)
         {
-            var specificationAttributesCount = (await _specificationAttributeService.GetSpecificationAttributesAsync()).TotalCount;
+            var specificationAttributes = await _specificationAttributeService.GetSpecificationAttributesWithOptionsAsync();
+            var specificationAttributesCount = specificationAttributes.Count;
 
             var specificationAttributesCountRootObject = new SpecificationAttributesCountRootObject
             {

--- a/Nop.Plugin.Api/Controllers/StoreController.cs
+++ b/Nop.Plugin.Api/Controllers/StoreController.cs
@@ -18,7 +18,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Configuration.MANAGE_STORES)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageStores))]
     public class StoreController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;
@@ -56,7 +56,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <param name="fields">Fields you want your json to contain</param>
         [HttpGet]
         [Route("/api/stores/current", Name = "GetCurrentStore")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_STORES, ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageStores), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
         [ProducesResponseType(typeof(StoresRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/StoreController.cs
+++ b/Nop.Plugin.Api/Controllers/StoreController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Nop.Core;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
@@ -19,7 +19,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_STORES))]
+    [AuthorizePermission(StandardPermission.Configuration.MANAGE_STORES)]
     public class StoreController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;
@@ -57,7 +57,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <param name="fields">Fields you want your json to contain</param>
         [HttpGet]
         [Route("/api/stores/current", Name = "GetCurrentStore")]
-        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_STORES), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
+        [AuthorizePermission(StandardPermission.Configuration.MANAGE_STORES, ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
         [ProducesResponseType(typeof(StoresRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/StoreController.cs
+++ b/Nop.Plugin.Api/Controllers/StoreController.cs
@@ -2,6 +2,7 @@
 using Nop.Core;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.Stores;
 using Nop.Plugin.Api.Helpers;

--- a/Nop.Plugin.Api/Controllers/StoreController.cs
+++ b/Nop.Plugin.Api/Controllers/StoreController.cs
@@ -19,7 +19,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageStores))]
+    [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_STORES))]
     public class StoreController : BaseApiController
     {
         private readonly IDTOHelper _dtoHelper;
@@ -57,7 +57,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <param name="fields">Fields you want your json to contain</param>
         [HttpGet]
         [Route("/api/stores/current", Name = "GetCurrentStore")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageStores), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
+        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_STORES), ignore: true)] // turn off all permission authorizations, access to this action is allowed to all authenticated customers
         [ProducesResponseType(typeof(StoresRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/TaxesController.cs
+++ b/Nop.Plugin.Api/Controllers/TaxesController.cs
@@ -21,7 +21,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.Configuration.MANAGE_TAX_SETTINGS)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageTaxSettings))]
     public class TaxesController : BaseApiController
     {
         private readonly ITaxCategoryService _taxCategoryService;

--- a/Nop.Plugin.Api/Controllers/TaxesController.cs
+++ b/Nop.Plugin.Api/Controllers/TaxesController.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿﻿using Microsoft.AspNetCore.Mvc;
 using Nop.Core.Domain.Tax;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTOs.Taxes;
 using Nop.Plugin.Api.Helpers;

--- a/Nop.Plugin.Api/Controllers/TaxesController.cs
+++ b/Nop.Plugin.Api/Controllers/TaxesController.cs
@@ -22,7 +22,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageTaxSettings))]
+    [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_TAX_SETTINGS))]
     public class TaxesController : BaseApiController
     {
         private readonly ITaxCategoryService _taxCategoryService;

--- a/Nop.Plugin.Api/Controllers/TaxesController.cs
+++ b/Nop.Plugin.Api/Controllers/TaxesController.cs
@@ -22,7 +22,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_TAX_SETTINGS))]
+    [AuthorizePermission(StandardPermission.Configuration.MANAGE_TAX_SETTINGS)]
     public class TaxesController : BaseApiController
     {
         private readonly ITaxCategoryService _taxCategoryService;

--- a/Nop.Plugin.Api/Controllers/TokenController.cs
+++ b/Nop.Plugin.Api/Controllers/TokenController.cs
@@ -178,7 +178,9 @@ namespace Nop.Plugin.Api.Controllers
                     claims.Add(new Claim(ClaimTypes.Name, customer.Email));
                 }
             }
-            var apiConfiguration = Singleton<AppSettings>.Instance.Get<ApiConfiguration>();
+            //fix due to nopCommerce 4.7 invert the order of the plugin initialization and the AppSettings singleton initialization
+            //var apiConfiguration = Singleton<AppSettings>.Instance.Get<ApiConfiguration>();
+            var apiConfiguration = new ApiConfiguration();
             var signingCredentials = new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(apiConfiguration.SecurityKey)), SecurityAlgorithms.HmacSha256);
             var token = new JwtSecurityToken(new JwtHeader(signingCredentials), new JwtPayload(claims));
             var accessToken = new JwtSecurityTokenHandler().WriteToken(token);

--- a/Nop.Plugin.Api/Controllers/TopicsController.cs
+++ b/Nop.Plugin.Api/Controllers/TopicsController.cs
@@ -25,7 +25,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(StandardPermission.ContentManagement.TOPICS_CREATE_EDIT_DELETE)]
+    [AuthorizePermission(nameof(StandardPermissionProvider.ManageTopics))]
     public class TopicsController : BaseApiController
     {
         private readonly ITopicService _topicService;

--- a/Nop.Plugin.Api/Controllers/TopicsController.cs
+++ b/Nop.Plugin.Api/Controllers/TopicsController.cs
@@ -26,7 +26,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermissionProvider.ManageTopics))]
+    [AuthorizePermission(nameof(StandardPermission.ContentManagement.TOPICS_CREATE_EDIT_DELETE))]
     public class TopicsController : BaseApiController
     {
         private readonly ITopicService _topicService;

--- a/Nop.Plugin.Api/Controllers/TopicsController.cs
+++ b/Nop.Plugin.Api/Controllers/TopicsController.cs
@@ -4,6 +4,7 @@ using Nop.Core.Domain.Topics;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.Orders;
 using Nop.Plugin.Api.DTOs.Topics;

--- a/Nop.Plugin.Api/Controllers/TopicsController.cs
+++ b/Nop.Plugin.Api/Controllers/TopicsController.cs
@@ -26,7 +26,7 @@ using System.Net;
 
 namespace Nop.Plugin.Api.Controllers
 {
-    [AuthorizePermission(nameof(StandardPermission.ContentManagement.TOPICS_CREATE_EDIT_DELETE))]
+    [AuthorizePermission(StandardPermission.ContentManagement.TOPICS_CREATE_EDIT_DELETE)]
     public class TopicsController : BaseApiController
     {
         private readonly ITopicService _topicService;

--- a/Nop.Plugin.Api/Controllers/WarehousesController.cs
+++ b/Nop.Plugin.Api/Controllers/WarehousesController.cs
@@ -67,7 +67,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/warehouses", Name = "GetWarehouses")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -99,7 +99,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/warehouses/{id}", Name = "GetWarehouseById")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.NotFound)]
@@ -132,7 +132,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/warehouses", Name = "CreateWarehouse")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -183,7 +183,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/warehouses/{id}", Name = "UpdateWarehouse")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -238,7 +238,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/warehouses/{id}", Name = "DeleteWarehouse")]
-        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
+        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/WarehousesController.cs
+++ b/Nop.Plugin.Api/Controllers/WarehousesController.cs
@@ -68,7 +68,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/warehouses", Name = "GetWarehouses")]
-        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
+        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -100,7 +100,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/warehouses/{id}", Name = "GetWarehouseById")]
-        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
+        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.NotFound)]
@@ -133,7 +133,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/warehouses", Name = "CreateWarehouse")]
-        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
+        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -184,7 +184,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/warehouses/{id}", Name = "UpdateWarehouse")]
-        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
+        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -239,7 +239,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/warehouses/{id}", Name = "DeleteWarehouse")]
-        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
+        [AuthorizePermission(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS)]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/Controllers/WarehousesController.cs
+++ b/Nop.Plugin.Api/Controllers/WarehousesController.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Nop.Core.Domain.Shipping;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Authorization.Attributes;
 using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Domain;
 using Nop.Plugin.Api.DTO.Errors;
 using Nop.Plugin.Api.DTO.Warehouses;
 using Nop.Plugin.Api.Factories;
@@ -29,14 +30,14 @@ namespace Nop.Plugin.Api.Controllers
     public class WarehousesController : BaseApiController
     {
         private readonly IWarehouseApiService _warehouseApiService;
-        private readonly IShippingService _shippingService;
+        private readonly IWarehouseService _warehouseService;
         private readonly IAddressService _addressService;
         private readonly IDTOHelper _dtoHelper;
         private readonly IFactory<Warehouse> _factory;
 
         public WarehousesController(
             IWarehouseApiService warehouseApiService,
-            IShippingService shippingService,
+            IWarehouseService warehouseService,
             IAddressService addressService,
             IJsonFieldsSerializer jsonFieldsSerializer,
             IAclService aclService,
@@ -53,7 +54,7 @@ namespace Nop.Plugin.Api.Controllers
             localizationService, pictureService)
         {
             _warehouseApiService = warehouseApiService;
-            _shippingService = shippingService;
+            _warehouseService = warehouseService;
             _addressService = addressService;
             _dtoHelper = dtoHelper;
             _factory = factory;
@@ -164,7 +165,7 @@ namespace Nop.Plugin.Api.Controllers
 
             warehouseDelta.Merge(warehouse);
 
-            await _shippingService.InsertWarehouseAsync(warehouse);
+            await _warehouseService.InsertWarehouseAsync(warehouse);
 
             await CustomerActivityService.InsertActivityAsync("AddNewWarehouse",
                                                    await LocalizationService.GetResourceAsync("ActivityLog.AddNewWarehouse"), warehouse);
@@ -220,7 +221,7 @@ namespace Nop.Plugin.Api.Controllers
 
             warehouseDelta.Merge(warehouse);
 
-            await _shippingService.UpdateWarehouseAsync(warehouse);
+            await _warehouseService.UpdateWarehouseAsync(warehouse);
 
             await CustomerActivityService.InsertActivityAsync("UpdateWarehouse",
                                                    await LocalizationService.GetResourceAsync("ActivityLog.UpdateWarehouse"), warehouse);
@@ -258,7 +259,7 @@ namespace Nop.Plugin.Api.Controllers
                 return Error(HttpStatusCode.NotFound, "warehouse", "warehouse not found");
             }
 
-            await _shippingService.DeleteWarehouseAsync(warehouseToDelete);
+            await _warehouseService.DeleteWarehouseAsync(warehouseToDelete);
 
             //activity log
             await CustomerActivityService.InsertActivityAsync("DeleteWarehouse", await LocalizationService.GetResourceAsync("ActivityLog.DeleteWarehouse"), warehouseToDelete);

--- a/Nop.Plugin.Api/Controllers/WarehousesController.cs
+++ b/Nop.Plugin.Api/Controllers/WarehousesController.cs
@@ -68,7 +68,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/warehouses", Name = "GetWarehouses")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
+        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -100,7 +100,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="401">Unauthorized</response>
         [HttpGet]
         [Route("/api/warehouses/{id}", Name = "GetWarehouseById")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
+        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.NotFound)]
@@ -133,7 +133,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPost]
         [Route("/api/warehouses", Name = "CreateWarehouse")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
+        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
@@ -184,7 +184,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpPut]
         [Route("/api/warehouses/{id}", Name = "UpdateWarehouse")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
+        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
         [ProducesResponseType(typeof(WarehousesRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), 422)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -239,7 +239,7 @@ namespace Nop.Plugin.Api.Controllers
 
         [HttpDelete]
         [Route("/api/warehouses/{id}", Name = "DeleteWarehouse")]
-        [AuthorizePermission(nameof(StandardPermissionProvider.ManageShippingSettings))]
+        [AuthorizePermission(nameof(StandardPermission.Configuration.MANAGE_SHIPPING_SETTINGS))]
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/Nop.Plugin.Api/DTOs/ShipmentItems/ShipmentItemDto.cs
+++ b/Nop.Plugin.Api/DTOs/ShipmentItems/ShipmentItemDto.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+using Nop.Plugin.Api.Attributes;
+using Nop.Plugin.Api.DTO.Base;
+using Nop.Plugin.Api.DTO.OrderItems;
+
+namespace Nop.Plugin.Api.DTOs.ShipmentItems
+{
+    [JsonObject(Title = "shipment_item")]
+    public class ShipmentItemDto : BaseDto
+    {
+        [JsonProperty("quantity")]
+        public int Quantity { get; set; }
+        
+        [JsonProperty("order_item")]
+        [DoNotMap]
+        public OrderItemDto OrderItem { get; set; }
+        
+        [JsonProperty("order_item_id")]
+        public int OrderItemId { get; set; }
+        
+        [JsonProperty("warehouse_id")]
+        public int WarehouseId { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/ShipmentItems/ShipmentItemsRootObject.cs
+++ b/Nop.Plugin.Api/DTOs/ShipmentItems/ShipmentItemsRootObject.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using Nop.Plugin.Api.DTO;
+
+namespace Nop.Plugin.Api.DTOs.ShipmentItems
+{
+    public class ShipmentItemsRootObject : ISerializableObject
+    {
+        [JsonProperty("shipment_items")]
+        public IList<ShipmentItemDto> ShipmentItems { get; set; } = new List<ShipmentItemDto>();
+        public string GetPrimaryPropertyName() => "shipment_items";
+        public Type GetPrimaryPropertyType() => typeof(ShipmentItemDto);
+    }
+}

--- a/Nop.Plugin.Api/DTOs/Shipments/ShipmentDto.cs
+++ b/Nop.Plugin.Api/DTOs/Shipments/ShipmentDto.cs
@@ -1,0 +1,61 @@
+﻿using Newtonsoft.Json;
+using Nop.Plugin.Api.DTO.Base;
+using Nop.Plugin.Api.DTOs.ShipmentItems;
+
+namespace Nop.Plugin.Api.DTO.OrderItems
+{
+    [JsonObject(Title = "shipment")]
+    public class ShipmentDto : BaseDto
+    {
+        private ICollection<ShipmentItemDto> _shipmentItems;
+        
+        /// <summary>
+        ///     Gets or sets the tracking number
+        /// </summary>
+        [JsonProperty("tracking_number")]
+        public string TrackingNumber { get; set; }
+        
+        /// <summary>
+        ///     Gets or sets the admin comment
+        /// </summary>
+        [JsonProperty("admin_comment")]
+        public string AdminComment { get; set; }
+        
+        /// <summary>
+        ///     Gets or sets the weight
+        /// </summary>
+        [JsonProperty("weight")]
+        public decimal TotalWeight { get; set; }
+        
+        /// <summary>
+        ///     Gets or sets the created on time
+        /// </summary>
+        [JsonProperty("created_on_utc")]
+        public DateTime CreatedOnUtc { get; set; }
+        
+        /// <summary>
+        ///     Gets or sets the shipped date
+        /// </summary>
+        [JsonProperty("shipped_date_utc")]
+        public DateTime? ShippedDateUtc { get; set; }
+        
+        /// <summary>
+        ///     Gets or sets the delivery date
+        /// </summary>
+        [JsonProperty("delivery_date_utc")]
+        public DateTime? DeliveryDateUtc { get; set; }
+        
+        /// <summary>
+        ///     Gets or sets the ready for pickup date
+        /// </summary>
+        [JsonProperty("ready_for_pickup_date_utc")]
+        public DateTime? ReadyForPickupDateUtc { get; set; }
+        
+        [JsonProperty("shipment_items")]
+        public ICollection<ShipmentItemDto> ShipmentItems
+        {
+            get => _shipmentItems ??= new List<ShipmentItemDto>();
+            set => _shipmentItems = value;
+        }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/Shipments/ShipmentsRootObject.cs
+++ b/Nop.Plugin.Api/DTOs/Shipments/ShipmentsRootObject.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using Nop.Plugin.Api.DTO;
+using Nop.Plugin.Api.DTO.OrderItems;
+
+namespace Nop.Plugin.Api.DTOs.Shipments
+{
+    public class ShipmentsRootObject : ISerializableObject
+    {
+        [JsonProperty("shipments")]
+        public IList<ShipmentDto> Shipments { get; set; } = new List<ShipmentDto>();
+        public string GetPrimaryPropertyName() => "shipments";
+        public Type GetPrimaryPropertyType() => typeof(ShipmentDto);
+    }
+}

--- a/Nop.Plugin.Api/Factories/CategoryFactory.cs
+++ b/Nop.Plugin.Api/Factories/CategoryFactory.cs
@@ -1,4 +1,4 @@
-﻿using Nop.Core.Domain.Catalog;
+using Nop.Core.Domain.Catalog;
 using Nop.Services.Catalog;
 
 namespace Nop.Plugin.Api.Factories
@@ -31,7 +31,7 @@ namespace Nop.Plugin.Api.Factories
             defaultCategory.PageSize = _catalogSettings.DefaultCategoryPageSize;
             defaultCategory.PageSizeOptions = _catalogSettings.DefaultCategoryPageSizeOptions;
             defaultCategory.Published = true;
-            defaultCategory.IncludeInTopMenu = true;
+            defaultCategory.ShowOnHomepage = true;
             defaultCategory.AllowCustomersToSelectPageSize = true;
 
             defaultCategory.CreatedOnUtc = DateTime.UtcNow;

--- a/Nop.Plugin.Api/Helpers/DTOHelper.cs
+++ b/Nop.Plugin.Api/Helpers/DTOHelper.cs
@@ -36,6 +36,7 @@ using Nop.Services.Media;
 using Nop.Services.Orders;
 using Nop.Services.Security;
 using Nop.Services.Seo;
+using Nop.Services.Shipping;
 using Nop.Services.Stores;
 
 namespace Nop.Plugin.Api.Helpers
@@ -62,6 +63,7 @@ namespace Nop.Plugin.Api.Helpers
         private readonly IStoreService _storeService;
         private readonly IUrlRecordService _urlRecordService;
         private readonly ISpecificationAttributeService _specificationAttributeService;
+        private readonly IShipmentService _shipmentService;
 
         private readonly Lazy<Task<Language>> _customerLanguage;
 
@@ -85,6 +87,7 @@ namespace Nop.Plugin.Api.Helpers
           IAuthenticationService authenticationService,
           ICustomerApiService customerApiService,
           ICurrencyService currencyService,
+          IShipmentService shipmentService,
           ISpecificationAttributeService specificationAttributeService)
         {
             _productService = productService;
@@ -105,6 +108,7 @@ namespace Nop.Plugin.Api.Helpers
             _addressService = addressService;
             _authenticationService = authenticationService;
             _customerApiService = customerApiService;
+            _shipmentService = shipmentService;
             _currencyService = currencyService;
             _specificationAttributeService = specificationAttributeService;
 
@@ -357,6 +361,16 @@ namespace Nop.Plugin.Api.Helpers
         {
             var taxCategoryDto = taxCategory.ToDto();
             return taxCategoryDto;
+        }
+
+        public async Task<ShipmentDto> PrepareShipmentDTOAsync(Shipment shipment)
+        {
+            var shipmentDto = shipment.ToDto();
+            var items = await _shipmentService.GetShipmentItemsByShipmentIdAsync(shipment.Id);
+            shipmentDto.ShipmentItems = items
+                .Select(shipmentItem => shipmentItem.ToDto())
+                .ToList();
+            return shipmentDto;
         }
 
         #region Private methods

--- a/Nop.Plugin.Api/Helpers/DTOHelper.cs
+++ b/Nop.Plugin.Api/Helpers/DTOHelper.cs
@@ -1,4 +1,4 @@
-﻿using Nop.Core.Domain.Catalog;
+using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Common;
 using Nop.Core.Domain.Directory;
 using Nop.Core.Domain.Localization;

--- a/Nop.Plugin.Api/Helpers/IDTOHelper.cs
+++ b/Nop.Plugin.Api/Helpers/IDTOHelper.cs
@@ -44,5 +44,6 @@ namespace Nop.Plugin.Api.Helpers
         Task<WarehouseDto> PrepareWarehouseDtoAsync(Warehouse warehouse);
         TopicDto PrepareTopicDTO(Topic topic);
         TaxCategoryDto prepareTaxCategoryDto(TaxCategory taxCategory);
+        Task<ShipmentDto> PrepareShipmentDTOAsync(Shipment item);
     }
 }

--- a/Nop.Plugin.Api/Infrastructure/ApiPlugin.cs
+++ b/Nop.Plugin.Api/Infrastructure/ApiPlugin.cs
@@ -1,4 +1,4 @@
-﻿using Nop.Core;
+using Nop.Core;
 using Nop.Core.Domain.Customers;
 using Nop.Core.Domain.Logging;
 using Nop.Core.Infrastructure;
@@ -153,7 +153,7 @@ namespace Nop.Plugin.Api.Infrastructure
             return $"{_webHelper.GetStoreLocation()}Admin/ApiAdmin/Settings";
         }
 
-        public async Task ManageSiteMapAsync(SiteMapNode rootNode)
+        public async Task ManageSiteMapAsync(AdminMenuItem rootNode)
         {
             var workingLanguage = await _workContext.GetWorkingLanguageAsync();
 
@@ -163,7 +163,7 @@ namespace Nop.Plugin.Api.Infrastructure
 
             const string adminUrlPart = "Admin/";
 
-            var pluginMainMenu = new SiteMapNode
+            var pluginMainMenu = new AdminMenuItem
             {
                 Title = pluginMenuName,
                 Visible = true,
@@ -171,7 +171,7 @@ namespace Nop.Plugin.Api.Infrastructure
                 IconClass = "fa-genderless"
             };
 
-            pluginMainMenu.ChildNodes.Add(new SiteMapNode
+            pluginMainMenu.ChildNodes.Add(new AdminMenuItem
             {
                 Title = settingsMenuName,
                 Url = _webHelper.GetStoreLocation() + adminUrlPart + "ApiAdmin/Settings",

--- a/Nop.Plugin.Api/Infrastructure/ApiStartup.cs
+++ b/Nop.Plugin.Api/Infrastructure/ApiStartup.cs
@@ -189,7 +189,7 @@ namespace Nop.Plugin.Api.Infrastructure
                       a.UseSwaggerUI(c =>
                 {
                     c.RoutePrefix = "api/swagger";
-                    c.SwaggerEndpoint("/api/swagger/v1/swagger.json", "Nop.Plugin.Api v4.80");
+                    c.SwaggerEndpoint("/api/swagger/v1/swagger.json", "Nop.Plugin.Api v4.70");
                     c.DocExpansion(Swashbuckle.AspNetCore.SwaggerUI.DocExpansion.None);
                 });
                   }

--- a/Nop.Plugin.Api/Infrastructure/ApiStartup.cs
+++ b/Nop.Plugin.Api/Infrastructure/ApiStartup.cs
@@ -61,7 +61,9 @@ namespace Nop.Plugin.Api.Infrastructure
 
             if (apiConfigSection != null)
             {
-                var apiConfig = Singleton<AppSettings>.Instance.Get<ApiConfiguration>();
+                //fix due to nopCommerce 4.7 invert the order of the plugin initialization and the AppSettings singleton initialization
+               // var apiConfig = Singleton<AppSettings>.Instance.Get<ApiConfiguration>();
+               var apiConfig = new ApiConfiguration();
 
 
                 if (!string.IsNullOrEmpty(apiConfig.SecurityKey))

--- a/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
+++ b/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
@@ -41,6 +41,7 @@ namespace Nop.Plugin.Api.Infrastructure
             services.AddScoped<IOrderApiService, OrderApiService>();
             services.AddScoped<IShoppingCartItemApiService, ShoppingCartItemApiService>();
             services.AddScoped<IOrderItemApiService, OrderItemApiService>();
+            services.AddScoped<IShipmentApiService, ShipmentApiService>();
             services.AddScoped<IProductAttributesApiService, ProductAttributesApiService>();
             services.AddScoped<IProductPictureService, ProductPictureService>();
             services.AddScoped<IProductAttributeConverter, ProductAttributeConverter>();

--- a/Nop.Plugin.Api/MappingExtensions/ShipmentDtoMappings.cs
+++ b/Nop.Plugin.Api/MappingExtensions/ShipmentDtoMappings.cs
@@ -1,0 +1,12 @@
+﻿using Nop.Core.Domain.Orders;
+using Nop.Core.Domain.Shipping;
+using Nop.Plugin.Api.AutoMapper;
+using Nop.Plugin.Api.DTO.OrderItems;
+
+namespace Nop.Plugin.Api.MappingExtensions
+{
+    public static class ShipmentDtoMappings
+    {
+        public static ShipmentDto ToDto(this Shipment shipment) => shipment.MapTo<Shipment, ShipmentDto>();
+    }
+}

--- a/Nop.Plugin.Api/MappingExtensions/ShipmentItemDtoMappings.cs
+++ b/Nop.Plugin.Api/MappingExtensions/ShipmentItemDtoMappings.cs
@@ -1,0 +1,13 @@
+﻿using Nop.Core.Domain.Orders;
+using Nop.Core.Domain.Shipping;
+using Nop.Plugin.Api.AutoMapper;
+using Nop.Plugin.Api.DTO.OrderItems;
+using Nop.Plugin.Api.DTOs.ShipmentItems;
+
+namespace Nop.Plugin.Api.MappingExtensions
+{
+    public static class ShipmentItemDtoMappings
+    {
+        public static ShipmentItemDto ToDto(this ShipmentItem shipmentItem) => shipmentItem.MapTo<ShipmentItem, ShipmentItemDto>();
+    }
+}

--- a/Nop.Plugin.Api/Models/OrdersParameters/OrdersParametersModel.cs
+++ b/Nop.Plugin.Api/Models/OrdersParameters/OrdersParametersModel.cs
@@ -22,7 +22,7 @@ namespace Nop.Plugin.Api.Models.OrdersParameters
         ///     A comma-separated list of order ids
         /// </summary>
         [JsonProperty("ids")]
-        public List<int> Ids { get; set; }
+        public HashSet<int> Ids { get; set; }
 
         /// <summary>
         ///     Amount of results (default: 50) (maximum: 250)

--- a/Nop.Plugin.Api/Models/ShipmentsParameters/ShipmentsParametersModel.cs
+++ b/Nop.Plugin.Api/Models/ShipmentsParameters/ShipmentsParametersModel.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Nop.Plugin.Api.Infrastructure;
+using Nop.Plugin.Api.ModelBinders;
+
+namespace Nop.Plugin.Api.Models.ShipmentsParameters
+{
+    [ModelBinder(typeof(ParametersModelBinder<ShipmentsParametersModel>))]
+    public class ShipmentsParametersModel
+    {
+        public ShipmentsParametersModel()
+        {
+            Limit = Constants.Configurations.DefaultLimit;
+            Page = Constants.Configurations.DefaultPageValue;
+            SinceId = 0;
+            Fields = string.Empty;
+        }
+
+        [JsonProperty("limit")]
+        public int Limit { get; set; }
+
+        [JsonProperty("page")]
+        public int Page { get; set; }
+
+        [JsonProperty("since_id")]
+        public int SinceId { get; set; }
+
+        [JsonProperty("fields")]
+        public string Fields { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/Nop.Plugin.Api.csproj
+++ b/Nop.Plugin.Api/Nop.Plugin.Api.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">0.0.1-local</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
     <Description>This plugin allows you to access/create Nop resources outside of the system</Description>
@@ -42,13 +42,14 @@
 
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.22" />
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+    <!-- Use JwtBearer 8.x to align with nopCommerce's IdentityModel 7.x dependencies -->
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.2.0" />
     <PackageReference Include="MimeTypes" Version="2.5.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -75,12 +76,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <Target Name="FilterCopyLocalItems" AfterTargets="ResolveLockFileCopyLocalProjectDeps">
-    <ItemGroup>
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' != 'Microsoft.AspNetCore.Rewrite' AND '%(Filename)' != 'System.IdentityModel.Tokens.Jwt'" />
-    </ItemGroup>
-  </Target>
 
   <!-- This target execute after "Build" target -->
   <Target Name="NopTarget" AfterTargets="Build">

--- a/Nop.Plugin.Api/Services/AddressApiService.cs
+++ b/Nop.Plugin.Api/Services/AddressApiService.cs
@@ -13,7 +13,7 @@ namespace Nop.Plugin.Api.Services
 {
     public class AddressApiService : IAddressApiService
     {
-        private readonly IShortTermCacheManager _cacheManager;
+        private readonly IShortTermCacheManager _shortTermCacheManager;
         private readonly ICountryService _countryService;
         private readonly IStateProvinceService _stateProvinceService;
         private readonly IRepository<Address> _addressRepository;
@@ -22,13 +22,13 @@ namespace Nop.Plugin.Api.Services
         public AddressApiService(
             IRepository<Address> addressRepository,
             IRepository<CustomerAddressMapping> customerAddressMappingRepository,
-            IShortTermCacheManager staticCacheManager,
+            IShortTermCacheManager shortTermShortTermCacheManager,
             ICountryService countryService,
             IStateProvinceService stateProvinceService)
         {
             _addressRepository = addressRepository;
             _customerAddressMappingRepository = customerAddressMappingRepository;
-            _cacheManager = staticCacheManager;
+            _shortTermCacheManager = shortTermShortTermCacheManager;
             _countryService = countryService;
             _stateProvinceService = stateProvinceService;
         }
@@ -47,11 +47,9 @@ namespace Nop.Plugin.Api.Services
                         join cam in _customerAddressMappingRepository.Table on address.Id equals cam.AddressId
                         where cam.CustomerId == customerId
                         select address;
+            
 
-            var key = _cacheManager.PrepareKey(NopCustomerServicesDefaults.CustomerAddressesCacheKey, customerId);
-
-
-            var addresses = await _cacheManager.GetAsync(async () => await query.ToListAsync(), key);
+            var addresses = await _shortTermCacheManager.GetAsync(async () => await query.ToListAsync(),NopCustomerServicesDefaults.CustomerAddressesCacheKey, customerId);
             return addresses.Select(a => a.ToDto()).ToList();
         }
 
@@ -70,10 +68,9 @@ namespace Nop.Plugin.Api.Services
                         join cam in _customerAddressMappingRepository.Table on address.Id equals cam.AddressId
                         where cam.CustomerId == customerId && address.Id == addressId
                         select address;
+ 
 
-            var key = _cacheManager.PrepareKey(NopCustomerServicesDefaults.CustomerAddressesCacheKey, customerId, addressId);
-
-            var addressEntity = await _cacheManager.GetAsync(async () => await query.FirstOrDefaultAsync(), key);
+            var addressEntity = await _shortTermCacheManager.GetAsync( async () => await query.FirstOrDefaultAsync(),NopCustomerServicesDefaults.CustomerAddressCacheKey, customerId, addressId );
             return addressEntity?.ToDto();
         }
 

--- a/Nop.Plugin.Api/Services/IOrderApiService.cs
+++ b/Nop.Plugin.Api/Services/IOrderApiService.cs
@@ -1,4 +1,5 @@
-﻿using Nop.Core.Domain.Orders;
+﻿#nullable enable
+using Nop.Core.Domain.Orders;
 using Nop.Core.Domain.Payments;
 using Nop.Core.Domain.Shipping;
 using Nop.Plugin.Api.Infrastructure;
@@ -10,12 +11,12 @@ namespace Nop.Plugin.Api.Services
         IList<Order> GetOrdersByCustomerId(int customerId);
 
         IList<Order> GetOrders(
-            IList<int> ids = null, DateTime? createdAtMin = null, DateTime? createdAtMax = null,
+            ISet<int>? ids = null, DateTime? createdAtMin = null, DateTime? createdAtMax = null,
             int limit = Constants.Configurations.DefaultLimit, int page = Constants.Configurations.DefaultPageValue,
             int sinceId = Constants.Configurations.DefaultSinceId, OrderStatus? status = null, PaymentStatus? paymentStatus = null,
             ShippingStatus? shippingStatus = null, int? customerId = null, int? storeId = null);
 
-        Order GetOrderById(int orderId);
+        Order? GetOrderById(int orderId);
 
         int GetOrdersCount(
             DateTime? createdAtMin = null, DateTime? createdAtMax = null, OrderStatus? status = null,

--- a/Nop.Plugin.Api/Services/IOrderApiService.cs
+++ b/Nop.Plugin.Api/Services/IOrderApiService.cs
@@ -21,5 +21,13 @@ namespace Nop.Plugin.Api.Services
             DateTime? createdAtMin = null, DateTime? createdAtMax = null, OrderStatus? status = null,
             PaymentStatus? paymentStatus = null, ShippingStatus? shippingStatus = null,
             int? customerId = null, int? storeId = null);
+
+        public IList<Order> GetOrdersForProductId(int productId,
+            DateTime? createdAtMin = null, DateTime? createdAtMax = null,
+            OrderStatus? status = null, int? storeId = null);
+
+        public IList<Order> GetOrdersForCategoryId(int categoryId,
+            DateTime? createdAtMin = null, DateTime? createdAtMax = null,
+            OrderStatus? status = null, int? storeId = null);
     }
 }

--- a/Nop.Plugin.Api/Services/IShipmentApiService.cs
+++ b/Nop.Plugin.Api/Services/IShipmentApiService.cs
@@ -1,0 +1,16 @@
+﻿#nullable enable
+using Nop.Core.Domain.Orders;
+using Nop.Core.Domain.Shipping;
+
+namespace Nop.Plugin.Api.Services
+{
+    public interface IShipmentApiService
+    {
+        Task<IList<Shipment>> GetShipmentsForOrderAsync(Order order, int limit, int page, int sinceId);
+        Task<Shipment> GetShipmentByIdAsync(int shipmentId);
+        Task DeleteShipmentAsync(Shipment shipment);
+        Task UpdateShipmentAsync(Shipment shipment);
+        public Task InsertShipmentAsync(Shipment newShipment);
+        public Task InsertShipmentItemsAsync(IList<ShipmentItem> newShipmentItems);
+    }
+}

--- a/Nop.Plugin.Api/Services/OrderApiService.cs
+++ b/Nop.Plugin.Api/Services/OrderApiService.cs
@@ -1,4 +1,5 @@
-﻿using Nop.Core.Domain.Catalog;
+﻿#nullable enable
+using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Orders;
 using Nop.Core.Domain.Payments;
 using Nop.Core.Domain.Shipping;
@@ -12,15 +13,13 @@ namespace Nop.Plugin.Api.Services
     {
         private readonly IRepository<Order> _orderRepository;
         private readonly IRepository<OrderItem> _orderItemRepository;
-        private readonly IRepository<Category> _categoryRepository;
         private readonly IRepository<ProductCategory> _productCategoryRepository;
 
         public OrderApiService(IRepository<Order> orderRepository, IRepository<OrderItem> orderItemRepository, 
-            IRepository<Category> categoryRepository, IRepository<ProductCategory> productCategoryRepository)
+             IRepository<ProductCategory> productCategoryRepository)
         {
             _orderRepository = orderRepository;
             _orderItemRepository = orderItemRepository;
-            _categoryRepository = categoryRepository;
             _productCategoryRepository = productCategoryRepository;
         }
 
@@ -31,11 +30,11 @@ namespace Nop.Plugin.Api.Services
                         orderby order.Id
                         select order;
 
-            return new ApiList<Order>(query, 0, Constants.Configurations.MaxLimit);
+            return query.ToApiList();
         }
 
         public IList<Order> GetOrders(
-            IList<int> ids = null, DateTime? createdAtMin = null, DateTime? createdAtMax = null,
+            ISet<int>? ids = null, DateTime? createdAtMin = null, DateTime? createdAtMax = null,
             int limit = Constants.Configurations.DefaultLimit, int page = Constants.Configurations.DefaultPageValue,
             int sinceId = Constants.Configurations.DefaultSinceId,
             OrderStatus? status = null, PaymentStatus? paymentStatus = null, ShippingStatus? shippingStatus = null, int? customerId = null,
@@ -51,155 +50,142 @@ namespace Nop.Plugin.Api.Services
             return new ApiList<Order>(query, page - 1, limit);
         }
 
-        public Order GetOrderById(int orderId)
-        {
-            if (orderId <= 0)
+        public Order? GetOrderById(int orderId) => orderId switch
             {
-                return null;
-            }
-
-            return _orderRepository.Table.FirstOrDefault(order => order.Id == orderId && !order.Deleted);
-        }
+                < 0 => null,
+                _ => _orderRepository.Table.FirstOrDefault(order => order.Id == orderId && !order.Deleted)
+            };
 
         public int GetOrdersCount(
             DateTime? createdAtMin = null, DateTime? createdAtMax = null, OrderStatus? status = null,
             PaymentStatus? paymentStatus = null, ShippingStatus? shippingStatus = null,
-            int? customerId = null, int? storeId = null)
-        {
-            var query = GetOrdersQuery(createdAtMin, createdAtMax, status, paymentStatus, shippingStatus, customerId: customerId, storeId: storeId);
-
-            return query.Count();
-        }
+            int? customerId = null, int? storeId = null) =>
+            GetOrdersQuery(createdAtMin,
+                createdAtMax,
+                status,
+                paymentStatus,
+                shippingStatus,
+                customerId: customerId,
+                storeId: storeId).Count();
 
         private IQueryable<Order> GetOrdersQuery(
             DateTime? createdAtMin = null, DateTime? createdAtMax = null, OrderStatus? status = null,
-            PaymentStatus? paymentStatus = null, ShippingStatus? shippingStatus = null, IList<int> ids = null,
-            int? customerId = null, int? storeId = null)
-        {
-            var query = _orderRepository.Table;
+            PaymentStatus? paymentStatus = null, ShippingStatus? shippingStatus = null, ISet<int>? ids = null,
+            int? customerId = null, int? storeId = null) =>
+            _orderRepository.Table
+                .Where(order => !order.Deleted)
+                .WhereCustomerId(customerId)
+                .WhereOrderIdIn(ids)
+                .WherePaymentStatus(paymentStatus)
+                .WhereShippingStatus(shippingStatus)
+                .WhereCreatedAtMin(createdAtMin)
+                .WhereCreatedAtMax(createdAtMax)
+                .WhereOrderStatus(status)
+                .WhereStoreId(storeId)
+                .Distinct()
+                .OrderBy(order => order.Id);
 
-            if (customerId != null)
-            {
-                query = query.Where(order => order.CustomerId == customerId);
-            }
-
-            if (ids != null && ids.Count > 0)
-            {
-                query = query.Where(c => ids.Contains(c.Id));
-            }
-
-            if (status != null)
-            {
-                query = query.Where(order => order.OrderStatusId == (int)status);
-            }
-
-            if (paymentStatus != null)
-            {
-                query = query.Where(order => order.PaymentStatusId == (int)paymentStatus);
-            }
-
-            if (shippingStatus != null)
-            {
-                query = query.Where(order => order.ShippingStatusId == (int)shippingStatus);
-            }
-
-            query = query.Where(order => !order.Deleted);
-
-            if (createdAtMin != null)
-            {
-                query = query.Where(order => order.CreatedOnUtc > createdAtMin.Value.ToUniversalTime());
-            }
-
-            if (createdAtMax != null)
-            {
-                query = query.Where(order => order.CreatedOnUtc < createdAtMax.Value.ToUniversalTime());
-            }
-
-            if (storeId != null)
-            {
-                query = query.Where(order => order.StoreId == storeId);
-            }
-
-            query = query.OrderBy(order => order.Id);
-
-            //query = query.Include(c => c.Customer);
-            //query = query.Include(c => c.BillingAddress);
-            //query = query.Include(c => c.ShippingAddress);
-            //query = query.Include(c => c.PickupAddress);
-            //query = query.Include(c => c.RedeemedRewardPointsEntry);
-            //query = query.Include(c => c.DiscountUsageHistory);
-            //query = query.Include(c => c.GiftCardUsageHistory);
-            //query = query.Include(c => c.OrderNotes);
-            //query = query.Include(c => c.OrderItems);
-            //query = query.Include(c => c.Shipments);
-
-            return query;
-        }
-        
         public IList<Order> GetOrdersForProductId(int productId, 
             DateTime? createdAtMin = null, DateTime? createdAtMax = null, 
-            OrderStatus? status = null, int? storeId = null)
-        {
-            var query = from orderItem in _orderItemRepository.Table
-                join order in _orderRepository.Table on orderItem.OrderId equals order.Id
-                where orderItem.ProductId == productId
-                select order;
-            
-            if (createdAtMin != null)
-            {
-                query = query.Where(order => order.CreatedOnUtc > createdAtMin.Value.ToUniversalTime());
-            }
+            OrderStatus? status = null, int? storeId = null
+            ) =>
+            _orderRepository.Table
+                .Where(order => !order.Deleted)
+                .WhereCreatedAtMin(createdAtMin)
+                .WhereCreatedAtMax(createdAtMax)
+                .WhereOrderStatus(status)
+                .WhereStoreId(storeId)
+                .WhereHasProductId(productId, _orderItemRepository)
+                .Distinct()
+                .OrderBy(order => order.Id)
+                .ToApiList();
 
-            if (createdAtMax != null)
-            {
-                query = query.Where(order => order.CreatedOnUtc < createdAtMax.Value.ToUniversalTime());
-            }
-            
-            if (status != null)
-            {
-                query = query.Where(order => order.OrderStatusId == (int)status);
-            }
-
-            if (storeId != null)
-            {
-                query = query.Where(order => order.StoreId == storeId);
-            }
-            
-            return new ApiList<Order>(query, 0, Constants.Configurations.MaxLimit);
-        }
-        
         public IList<Order> GetOrdersForCategoryId(int categoryId, 
             DateTime? createdAtMin = null, DateTime? createdAtMax = null, 
-            OrderStatus? status = null, int? storeId = null)
+            OrderStatus? status = null, int? storeId = null) =>
+            _orderRepository.Table
+                .WhereCreatedAtMin(createdAtMin)
+                .WhereCreatedAtMax(createdAtMax)
+                .WhereOrderStatus(status)
+                .WhereStoreId(storeId)
+                .WhereHasCategoryId(categoryId, _orderItemRepository, _productCategoryRepository)
+                .Distinct()
+                .OrderBy(order => order.Id)
+                .ToApiList();
+    }
+    
+    internal static class OrderServiceExtensions
+    {
+        public static IQueryable<Order> WhereOrderStatus(this IQueryable<Order> order, OrderStatus? status) => status switch
         {
-            var query = from productCategory in _productCategoryRepository.Table 
-                join orderItem in _orderItemRepository.Table on productCategory.ProductId equals orderItem.ProductId
-                join order in _orderRepository.Table on orderItem.OrderId equals order.Id
+            null => order,
+            _ => order.Where(o => o.OrderStatusId == (int)status)
+        };
+        
+        public static IQueryable<Order> WhereShippingStatus(this IQueryable<Order> order, ShippingStatus? status) => status switch
+        {
+            null => order,
+            _ => order.Where(o => o.ShippingStatusId == (int)status)
+        };
+        
+        public static IQueryable<Order> WherePaymentStatus(this IQueryable<Order> order, PaymentStatus? status) => status switch
+        {
+            null => order,
+            _ => order.Where(o => o.PaymentStatusId == (int)status)
+        };
+        
+        public static IQueryable<Order> WhereCreatedAtMin(this IQueryable<Order> order, DateTime? createdAtMin) => createdAtMin switch
+        {
+            null => order,
+            _ => order.Where(o => o.CreatedOnUtc > createdAtMin.Value.ToUniversalTime())
+        };
+        
+        public static IQueryable<Order> WhereCreatedAtMax(this IQueryable<Order> order, DateTime? createdAtMax) => createdAtMax switch
+        {
+            null => order,
+            _ => order.Where(o => o.CreatedOnUtc < createdAtMax.Value.ToUniversalTime())
+        };
+        
+        public static IQueryable<Order> WhereStoreId(this IQueryable<Order> order, int? storeId) => storeId switch
+        {
+            null => order,
+            _ => order.Where(o => o.StoreId == storeId)
+        };
+        
+        public static IQueryable<Order> WhereCustomerId(this IQueryable<Order> order, int? customerId) => customerId switch
+        {
+            null => order,
+            _ => order.Where(o => o.CustomerId == customerId)
+        };
+        
+        public static IQueryable<Order> WhereOrderIdIn(this IQueryable<Order> order, ISet<int>? orderIds) => orderIds switch
+        {
+            null => order,
+            _ => order.Where(o => orderIds.Contains(o.Id))
+        };
+        
+        public static IQueryable<Order> WhereHasProductId(this IQueryable<Order> order, int? productId, 
+            IRepository<OrderItem> orderItemRepository) => productId switch
+        {
+            null => order,
+            _ => from o in  order
+                join orderItem in orderItemRepository.Table on o.Id equals orderItem.OrderId
+                where orderItem.ProductId == productId
+                select o
+        };
+        
+        public static IQueryable<Order> WhereHasCategoryId(this IQueryable<Order> order, int? categoryId, 
+            IRepository<OrderItem> orderItemRepository, IRepository<ProductCategory> productCategoryRepository) => categoryId switch
+        {
+            null => order,
+            _ => from o in  order
+                join orderItem in orderItemRepository.Table on o.Id equals orderItem.OrderId
+                join productCategory in productCategoryRepository.Table on orderItem.ProductId equals productCategory.ProductId
                 where productCategory.CategoryId == categoryId
-                select order;
-            query = query.Distinct();
-            
-            if (createdAtMin != null)
-            {
-                query = query.Where(order => order.CreatedOnUtc > createdAtMin.Value.ToUniversalTime());
-            }
-
-            if (createdAtMax != null)
-            {
-                query = query.Where(order => order.CreatedOnUtc < createdAtMax.Value.ToUniversalTime());
-            }
-            
-            if (status != null)
-            {
-                query = query.Where(order => order.OrderStatusId == (int)status);
-            }
-
-            if (storeId != null)
-            {
-                query = query.Where(order => order.StoreId == storeId);
-            }
-
-            return new ApiList<Order>(query, 0, Constants.Configurations.MaxLimit);
-        }
+                select o
+        };
+        
+        public static ApiList<T>  ToApiList<T>(this IQueryable<T> query, int pageIndex = 0, int pageSize = Constants.Configurations.MaxLimit) => 
+             new (query, pageIndex, pageSize);
     }
 }

--- a/Nop.Plugin.Api/Services/ShipmentApiService.cs
+++ b/Nop.Plugin.Api/Services/ShipmentApiService.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using Nop.Core.Domain.Orders;
+using Nop.Core.Domain.Shipping;
+using Nop.Plugin.Api.DataStructures;
+using Nop.Services.Shipping;
+
+namespace Nop.Plugin.Api.Services
+{
+    public class ShipmentApiService(IShipmentService shipmentService) : IShipmentApiService
+    {
+        public async Task<IList<Shipment>> GetShipmentsForOrderAsync(Order order, int limit, int page, int sinceId)
+        {
+            var orderShipments = (await shipmentService.GetShipmentsByOrderIdAsync(order.Id)).AsQueryable();
+            return new ApiList<Shipment>(orderShipments, page - 1, limit);
+        }
+
+        public async Task<Shipment> GetShipmentByIdAsync(int shipmentId) => await shipmentService.GetShipmentByIdAsync(shipmentId);
+        public async Task DeleteShipmentAsync(Shipment shipment) => await shipmentService.DeleteShipmentAsync(shipment);
+        public async Task UpdateShipmentAsync(Shipment shipment) => await shipmentService.UpdateShipmentAsync(shipment);
+        public async Task InsertShipmentAsync(Shipment newShipment) => 
+            await shipmentService.InsertShipmentAsync(newShipment);
+
+        public async Task InsertShipmentItemsAsync(IList<ShipmentItem> newShipmentItems)
+        {
+            foreach (var shipmentItem in newShipmentItems)
+            {
+                await shipmentService.InsertShipmentItemAsync(shipmentItem);
+            }        
+        }
+    }
+}

--- a/Nop.Plugin.Api/plugin.json
+++ b/Nop.Plugin.Api/plugin.json
@@ -1,11 +1,11 @@
 ﻿{
-  "Group": "Api",
-  "FriendlyName": "Api plugin",
-  "SystemName": "Nop.Plugin.Api",
-  "Version": "4.8.0",
-  "SupportedVersions": [ "4.80" ],
-  "Author": "Nop-Templates team",
-  "DisplayOrder": -1,
-  "FileName": "Nop.Plugin.Api.dll",
-  "Description": "This plugin is Restfull API for nopCommerce"
+    "Group": "Api",
+    "FriendlyName": "Api plugin",
+    "SystemName": "Nop.Plugin.Api",
+    "Version": "4.7.0",
+    "SupportedVersions": [ "4.70" ],
+    "Author": "Nop-Templates team",
+    "DisplayOrder": -1,
+    "FileName": "Nop.Plugin.Api.dll",
+    "Description": "This plugin is Restfull API for nopCommerce"
 }

--- a/Nop.Plugin.Api/plugin.json
+++ b/Nop.Plugin.Api/plugin.json
@@ -1,9 +1,9 @@
-﻿{
+{
   "Group": "Api",
   "FriendlyName": "Api plugin",
   "SystemName": "Nop.Plugin.Api",
-  "Version": "4.8.0",
-  "SupportedVersions": [ "4.80" ],
+  "Version": "4.9.0",
+  "SupportedVersions": [ "4.90" ],
   "Author": "Nop-Templates team",
   "DisplayOrder": -1,
   "FileName": "Nop.Plugin.Api.dll",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# API plugin for nopCommerce 4.80
+# API plugin for nopCommerce 4.90
 
-This plugin provides a RESTful API for managing resources in nopCommerce 4.8.
-For the other versions of nopCommerce, please refer to the the other releases and branches.
+This plugin provides a RESTful API for managing resources in nopCommerce 4.9.
+For the other versions of nopCommerce, please refer to the other releases and branches.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,56 @@
 # API plugin for nopCommerce 4.90
 
+<!-- Replace YOUR_USERNAME with your GitHub username/organization -->
+[![CI Build](https://github.com/YOUR_USERNAME/api-for-nopcommerce/actions/workflows/ci.yml/badge.svg)](https://github.com/YOUR_USERNAME/api-for-nopcommerce/actions/workflows/ci.yml)
+
 This plugin provides a RESTful API for managing resources in nopCommerce 4.9.
 For the other versions of nopCommerce, please refer to the other releases and branches.
 
+## Continuous Integration
+
+This project uses GitHub Actions for CI/CD. The build process:
+
+1. Checks out this repository and nopCommerce at the compatible version (currently `release-4.90.3`)
+2. Builds nopCommerce core and framework
+3. Builds the API plugin
+4. Verifies the plugin output is in the correct location
+
+The nopCommerce version is automatically pulled based on the `NOPCOMMERCE_VERSION` environment variable in the workflow file (`.github/workflows/ci.yml`). This ensures the build always uses a compatible version.
+
+**Note:** Tests are currently disabled in CI because the test project uses .NET Framework 4.6.1, which is not supported on Linux runners. To enable tests, the test project needs to be upgraded to .NET 6+.
+
+### Updating nopCommerce Version
+
+To update the nopCommerce version used in CI and development:
+
+1. Update `NOPCOMMERCE_VERSION` in `.github/workflows/ci.yml`
+2. Update the version in both `setup-dev.sh` and `setup-dev.ps1`
+3. Update `SupportedVersions` in `Nop.Plugin.Api/plugin.json`
+4. Test the build locally before pushing changes
+
 ## Installation
 
-1. clone the [NopCommerce](https://github.com/nopSolutions/nopCommerce) repository (`develop` branch) into folder called `nopCommerce`
+### Quick Setup (Recommended)
+
+Use the provided setup script to automatically clone and build nopCommerce at the correct version:
+
+```bash
+# Linux/macOS
+./setup-dev.sh
+
+# Windows (PowerShell)
+.\setup-dev.ps1
+```
+
+The setup script will:
+- Clone nopCommerce at the compatible version (release-4.90.3) if not already present
+- Check for version mismatches in existing installations
+- Build both nopCommerce and the API plugin
+- Display next steps
+
+### Manual Installation
+
+1. clone the [NopCommerce](https://github.com/nopSolutions/nopCommerce) repository (tag `release-4.90.3` or compatible) into folder called `nopCommerce`
 1. clone this repository into the same folder where the `nopCommerce` folder is located
 1. build the nopCommerce solution
 1. build the api-for-nopcommerce solution (the output will be placed inside the nopCommerce directory)

--- a/docs/requests/.gitignore
+++ b/docs/requests/.gitignore
@@ -1,0 +1,1 @@
+*.private.env.json

--- a/docs/requests/README.md
+++ b/docs/requests/README.md
@@ -1,0 +1,3 @@
+# Requests
+
+These are .http files for use in Visual Studio Code or Rider for testing REST calls. s

--- a/docs/requests/authn.http
+++ b/docs/requests/authn.http
@@ -1,0 +1,12 @@
+### Authenticate get token
+POST {{host}}/token
+Content-Type: application/json-patch+json
+
+{
+  "guest": false,
+  "username": "{{username}}",
+  "password": "{{password}}",
+  "remember_me": true
+}
+
+> {% client.global.set("auth_token", response.body.access_token); %}

--- a/docs/requests/http-client.env.json
+++ b/docs/requests/http-client.env.json
@@ -1,0 +1,5 @@
+{
+  "local": {
+    "host": "https://localhost:5501"
+  }
+}

--- a/docs/requests/orders.http
+++ b/docs/requests/orders.http
@@ -1,0 +1,9 @@
+import authn.http
+
+## Get Token
+run authn.http
+
+### Get shipments for an order
+@orderId = 38920
+GET {{host}}/api/orders/{{orderId}}
+Authorization: Bearer {{auth_token}}

--- a/docs/requests/orders.http
+++ b/docs/requests/orders.http
@@ -3,7 +3,17 @@ import authn.http
 ## Get Token
 run authn.http
 
-### Get shipments for an order
+### Get an order by ID
 @orderId = 38920
 GET {{host}}/api/orders/{{orderId}}
+Authorization: Bearer {{auth_token}}
+
+### Get orders by Product ID
+@productId = 945
+GET {{host}}/api/orders/product/{{productId}}
+Authorization: Bearer {{auth_token}}
+
+### Get orders by Category ID
+@categoryId = 10
+GET {{host}}/api/orders/category/{{categoryId}}
 Authorization: Bearer {{auth_token}}

--- a/docs/requests/shipments.http
+++ b/docs/requests/shipments.http
@@ -1,0 +1,50 @@
+import authn.http
+
+## Get Token
+run authn.http
+
+### Get shipments for an order
+@orderId = 38920
+GET {{host}}/api/orders/{{orderId}}/shipments
+Authorization: Bearer {{auth_token}}
+
+### Create shipment for an order
+POST {{host}}/api/orders/{{orderId}}/shipments
+Authorization: Bearer {{auth_token}}
+Content-Type: application/json-patch+json
+
+{
+  "shipment": {
+    "tracking_number": "1234567",
+    "admin_comment": "",
+    "weight": 1.6,
+    "shipment_items": [
+      {
+        "order_item_id": 67170,
+        "quantity": 1
+      }]
+  }
+}
+
+> {% client.global.set("shipmentId", response.body.shipments[0].id); %}
+
+### Update shipped date
+PUT {{host}}/api/orders/{{orderId}}/shipments/{{shipmentId}}
+Authorization: Bearer {{auth_token}}
+Content-Type: application/json-patch+json
+
+{
+  "shipment": {
+    "shipped_date_utc": "{{$isoTimestamp}}"
+  }
+}
+
+
+### Get a shipment by ID for an order
+GET {{host}}/api/orders/{{orderId}}/shipments/{{shipmentId}}
+Authorization: Bearer {{auth_token}}
+
+### Delete shipment for an order
+@shipmentId = 40
+DELETE {{host}}/api/orders/{{orderId}}/shipments/{{shipmentId}}
+Authorization: Bearer {{auth_token}}

--- a/setup-dev.ps1
+++ b/setup-dev.ps1
@@ -1,0 +1,80 @@
+# Setup script for local development (PowerShell)
+# This script clones nopCommerce at the correct version if it's not already present
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ParentDir = Split-Path -Parent $ScriptDir
+$NopCommerceDir = Join-Path $ParentDir "nopCommerce"
+$NopCommerceVersion = if ($env:NOPCOMMERCE_VERSION) { $env:NOPCOMMERCE_VERSION } else { "release-4.90.3" }
+
+Write-Host "🚀 Setting up development environment for API plugin" -ForegroundColor Cyan
+Write-Host ""
+
+# Check if nopCommerce directory exists
+if (Test-Path $NopCommerceDir) {
+    Write-Host "📁 nopCommerce directory already exists at: $NopCommerceDir" -ForegroundColor Yellow
+    
+    # Check if it's a git repository
+    if (Test-Path (Join-Path $NopCommerceDir ".git")) {
+        Push-Location $NopCommerceDir
+        try {
+            $CurrentVersion = git describe --tags --exact-match 2>$null
+            if (-not $CurrentVersion) {
+                $CurrentVersion = git rev-parse --short HEAD
+            }
+            Write-Host "   Current version: $CurrentVersion" -ForegroundColor Gray
+            
+            if ($CurrentVersion -ne $NopCommerceVersion) {
+                Write-Host ""
+                Write-Host "⚠️  Warning: nopCommerce is at $CurrentVersion but plugin expects $NopCommerceVersion" -ForegroundColor Yellow
+                Write-Host "   You may want to checkout the correct version:" -ForegroundColor Yellow
+                Write-Host "   cd $NopCommerceDir; git checkout $NopCommerceVersion" -ForegroundColor Gray
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    else {
+        Write-Host "   ⚠️  Directory exists but is not a git repository" -ForegroundColor Yellow
+    }
+}
+else {
+    Write-Host "📦 Cloning nopCommerce at $NopCommerceVersion..." -ForegroundColor Cyan
+    git clone --branch $NopCommerceVersion --depth 1 `
+        https://github.com/nopSolutions/nopCommerce.git $NopCommerceDir
+    Write-Host "   ✅ nopCommerce cloned successfully" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "🔨 Building nopCommerce..." -ForegroundColor Cyan
+Push-Location (Join-Path $NopCommerceDir "src")
+try {
+    dotnet restore
+    dotnet build --configuration Release --no-restore
+}
+finally {
+    Pop-Location
+}
+
+Write-Host ""
+Write-Host "🔨 Building API plugin..." -ForegroundColor Cyan
+Push-Location $ScriptDir
+try {
+    dotnet restore
+    dotnet build --configuration Release --no-restore
+}
+finally {
+    Pop-Location
+}
+
+Write-Host ""
+Write-Host "✅ Setup complete!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor Cyan
+Write-Host "  1. Run the Nop.Web project: cd $NopCommerceDir\src\Presentation\Nop.Web; dotnet run" -ForegroundColor Gray
+Write-Host "  2. Complete nopCommerce installation in browser" -ForegroundColor Gray
+Write-Host "  3. Install the API plugin from Admin > Configuration > Local plugins" -ForegroundColor Gray
+Write-Host "  4. Visit /api/swagger to explore the API" -ForegroundColor Gray
+Write-Host ""

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Setup script for local development
+# This script clones nopCommerce at the correct version if it's not already present
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+NOPCOMMERCE_DIR="$PARENT_DIR/nopCommerce"
+NOPCOMMERCE_VERSION="${NOPCOMMERCE_VERSION:-release-4.90.3}"
+
+echo "🚀 Setting up development environment for API plugin"
+echo ""
+
+# Check if nopCommerce directory exists
+if [ -d "$NOPCOMMERCE_DIR" ]; then
+    echo "📁 nopCommerce directory already exists at: $NOPCOMMERCE_DIR"
+    
+    # Check if it's a git repository
+    if [ -d "$NOPCOMMERCE_DIR/.git" ]; then
+        cd "$NOPCOMMERCE_DIR"
+        CURRENT_VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
+        echo "   Current version: $CURRENT_VERSION"
+        
+        if [ "$CURRENT_VERSION" != "$NOPCOMMERCE_VERSION" ]; then
+            echo ""
+            echo "⚠️  Warning: nopCommerce is at $CURRENT_VERSION but plugin expects $NOPCOMMERCE_VERSION"
+            echo "   You may want to checkout the correct version:"
+            echo "   cd $NOPCOMMERCE_DIR && git checkout $NOPCOMMERCE_VERSION"
+        fi
+    else
+        echo "   ⚠️  Directory exists but is not a git repository"
+    fi
+else
+    echo "📦 Cloning nopCommerce at $NOPCOMMERCE_VERSION..."
+    git clone --branch "$NOPCOMMERCE_VERSION" --depth 1 \
+        https://github.com/nopSolutions/nopCommerce.git "$NOPCOMMERCE_DIR"
+    echo "   ✅ nopCommerce cloned successfully"
+fi
+
+echo ""
+echo "🔨 Building nopCommerce..."
+cd "$NOPCOMMERCE_DIR/src"
+dotnet restore
+dotnet build --configuration Release --no-restore
+
+echo ""
+echo "🔨 Building API plugin..."
+cd "$SCRIPT_DIR"
+dotnet restore
+dotnet build --configuration Release --no-restore
+
+echo ""
+echo "✅ Setup complete!"
+echo ""
+echo "Next steps:"
+echo "  1. Run the Nop.Web project: cd $NOPCOMMERCE_DIR/src/Presentation/Nop.Web && dotnet run"
+echo "  2. Complete nopCommerce installation in browser"
+echo "  3. Install the API plugin from Admin > Configuration > Local plugins"
+echo "  4. Visit /api/swagger to explore the API"
+echo ""


### PR DESCRIPTION
## Summary

Fixes 403 Forbidden errors caused by incorrect use of `nameof()` with `StandardPermission` constants in the nopCommerce 4.90 upgrade.

## Problem

In commit 63d0810, when migrating from `StandardPermissionProvider` to the new `StandardPermission` structure, permission references were incorrectly wrapped with `nameof()`. This caused the permission checker to receive only the constant name instead of the actual permission string value.

**Example:**
- ❌ Broken: `nameof(StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION)` → `"PUBLIC_STORE_ALLOW_NAVIGATION"`
- ✅ Fixed: `StandardPermission.PublicStore.PUBLIC_STORE_ALLOW_NAVIGATION` → `"PublicStore.PublicStoreAllowNavigation"`

Since the permission service checks against the actual string values stored in the database, the `nameof()` wrapper caused all permission checks to fail, resulting in 403 Forbidden responses for API requests.

## Changes

- Removed `nameof()` from all `[AuthorizePermission(...)]` attributes
- Removed `nameof()` from all `_permissionService.AuthorizeAsync(...)` calls  
- Updated 20 controller files with 51 total changes

## Testing

- ✅ Build succeeds with no errors
- ✅ Verified API requests no longer return 403 when properly authenticated
- ✅ Permission checks now correctly validate against database permission records